### PR TITLE
docs: add AGENTS.md for cloud development setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# AGENTS.md
+
+Guidance for AI agents working in this repository.
+
+## Repository layout
+
+| Branch | Contents |
+|--------|----------|
+| `main` | Placeholder (`README.md` only) |
+| `cursor/sungjwa-hunter-simulator-ace2` | **성좌 헌터 시뮬레이션** — Python CLI in `sungjwa_hunter_sim/` |
+
+If `sungjwa_hunter_sim/` is missing, check out the simulator branch:
+
+```bash
+git fetch origin cursor/sungjwa-hunter-simulator-ace2
+git checkout cursor/sungjwa-hunter-simulator-ace2
+```
+
+## Cursor Cloud specific instructions
+
+### Stack
+
+- **Python 3.10+** (VM has 3.12). **No pip dependencies** — stdlib + `unittest` only.
+- No Docker, databases, or long-running servers.
+
+### Working directory
+
+All commands assume `cd sungjwa_hunter_sim` (relative to repo root).
+
+### Tests
+
+```bash
+cd sungjwa_hunter_sim
+python3 -m unittest discover -s tests -v
+```
+
+### Run the simulator (dev)
+
+```bash
+cd sungjwa_hunter_sim
+python3 main.py --hunter kim_dokja --seed 42 --turns 4
+python3 main.py --list-hunters
+python3 main.py --list-monsters
+python3 main.py --query '[외부 업데이트] 질의: randomness_intensity=2.6'
+```
+
+Use `--interactive` only when a TTY is available; prefer `--turns`, `--seed`, and `--query` in cloud/CI.
+
+### Lint / format
+
+No project-level Ruff, flake8, or mypy config. Optional sanity check:
+
+```bash
+python3 -m compileall -q sungjwa_hunter_sim/src sungjwa_hunter_sim/tests
+```
+
+### Config side effects
+
+`main.py` persists external-update changes to `config/variables.json` unless `--no-persist` is set. Tests use temp copies of config and do not require resetting the repo file after `unittest`.
+
+### Branch checkout note
+
+Cloud VMs may start on `main` (empty tree). The application under test is not on `main`; switch to `cursor/sungjwa-hunter-simulator-ace2` before running tests or the CLI.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with repository layout, branch checkout notes, and **Cursor Cloud specific instructions** for running the 성좌 헌터 simulator (Python 3.10+ stdlib, no pip deps).

Environment setup validation (on `cursor/sungjwa-hunter-simulator-ace2`):
- `python3 -m unittest discover -s tests -v` — 24 tests OK
- `python3 main.py --hunter kim_dokja --seed 42 --turns 4` — simulation runs end-to-end

VM update script: `true` (no third-party install step).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7601fc9a-4dcc-4315-993b-03f8f291fd0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7601fc9a-4dcc-4315-993b-03f8f291fd0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

