### PR TITLE
feat(godot): item catalog and inventory UI

### DIFF
--- a/fantasy_simulator/client/godot/README.md
+++ b/fantasy_simulator/client/godot/README.md
@@ -34,6 +34,8 @@ client/godot/
   project.godot
   scenes/main_menu.tscn      # 새 게임 → 2D 탐험
   scenes/exploration.tscn   # WASD + 타일 ↔ 시뮬 좌표
+  scenes/inventory.tscn     # 인벤 · 착용/사용
+  scenes/item_catalog.tscn  # 아이템 도감 (213+)
   scripts/net/api_client.gd # sync_position, run_turn
   scripts/player/player_controller.gd
 ```

--- a/fantasy_simulator/client/godot/scenes/exploration.gd
+++ b/fantasy_simulator/client/godot/scenes/exploration.gd
@@ -152,5 +152,13 @@ func _on_api_error(message: String) -> void:
 	_narrative.text += "\n[오류] %s\n" % message
 
 
+func _on_inventory_pressed() -> void:
+	get_tree().change_scene_to_file("res://scenes/inventory.tscn")
+
+
+func _on_catalog_pressed() -> void:
+	get_tree().change_scene_to_file("res://scenes/item_catalog.tscn")
+
+
 func _on_back_pressed() -> void:
 	get_tree().change_scene_to_file("res://scenes/main_menu.tscn")

--- a/fantasy_simulator/client/godot/scenes/exploration.tscn
+++ b/fantasy_simulator/client/godot/scenes/exploration.tscn
@@ -62,12 +62,28 @@ offset_right = 120.0
 offset_bottom = 680.0
 text = "탐험"
 
-[node name="BackButton" type="Button" parent="CanvasLayer"]
+[node name="InvButton" type="Button" parent="CanvasLayer"]
 offset_left = 130.0
 offset_top = 648.0
-offset_right = 220.0
+offset_right = 210.0
+offset_bottom = 680.0
+text = "인벤"
+
+[node name="CatalogButton" type="Button" parent="CanvasLayer"]
+offset_left = 220.0
+offset_top = 648.0
+offset_right = 300.0
+offset_bottom = 680.0
+text = "도감"
+
+[node name="BackButton" type="Button" parent="CanvasLayer"]
+offset_left = 310.0
+offset_top = 648.0
+offset_right = 400.0
 offset_bottom = 680.0
 text = "메뉴"
 
 [connection signal="pressed" from="CanvasLayer/ExploreButton" to="." method="_on_explore_pressed"]
+[connection signal="pressed" from="CanvasLayer/InvButton" to="." method="_on_inventory_pressed"]
+[connection signal="pressed" from="CanvasLayer/CatalogButton" to="." method="_on_catalog_pressed"]
 [connection signal="pressed" from="CanvasLayer/BackButton" to="." method="_on_back_pressed"]

--- a/fantasy_simulator/client/godot/scenes/inventory.gd
+++ b/fantasy_simulator/client/godot/scenes/inventory.gd
@@ -1,0 +1,221 @@
+extends Control
+
+var _heroes: Dictionary = {}
+var _inventory: Dictionary = {}
+var _owned_ids: Array = []
+var _consumables: Dictionary = {}
+var _selected_item_id: String = ""
+var _item_cache: Dictionary = {}
+
+
+func _ready() -> void:
+	ApiClient.api_error.connect(_on_api_error)
+	$VBox/BackButton.pressed.connect(_on_back_pressed)
+	$VBox/CatalogButton.pressed.connect(_on_catalog_pressed)
+	$VBox/ActionRow/EquipButton.pressed.connect(_on_equip_pressed)
+	$VBox/ActionRow/UseButton.pressed.connect(_on_use_pressed)
+	$VBox/ActionRow/StarterPackButton.pressed.connect(_on_starter_pack_pressed)
+	if ApiClient.session_id.is_empty():
+		$VBox/StatusLabel.text = "세션이 없습니다. 메인 메뉴에서 새 게임을 시작하세요."
+		return
+	await _reload_all()
+
+
+func _current_character_id() -> String:
+	var opt: OptionButton = $VBox/CharacterOption
+	if opt.item_count == 0:
+		return "gareth_ironshield"
+	var sel := opt.selected
+	if sel < 0:
+		sel = 0
+	return str(opt.get_item_metadata(sel))
+
+
+func _reload_all() -> void:
+	$VBox/StatusLabel.text = "인벤토리 불러오는 중…"
+	var status: Dictionary = await ApiClient.fetch_progression_status()
+	var catalog: Dictionary = await ApiClient.fetch_item_catalog("", "", "", 500)
+	_heroes = status.get("heroes", {})
+	_inventory = catalog.get("inventory", {})
+	_owned_ids = list(_inventory.get("equipment_owned", []))
+	_consumables = _inventory.get("consumables", {})
+	_item_cache.clear()
+	for it in catalog.get("items", []):
+		if it is Dictionary:
+			_item_cache[str(it.get("item_id", ""))] = it
+	await _populate_characters()
+	_refresh_lists()
+	_refresh_equipped()
+	var total_items := int(catalog.get("counts", {}).get("total", 0))
+	$VBox/StatusLabel.text = "도감 %s종 · 보유 장비 %d · 소비 %d" % [
+		total_items,
+		_owned_ids.size(),
+		_consumables.size(),
+	]
+
+
+func _populate_characters() -> void:
+	var opt: OptionButton = $VBox/CharacterOption
+	if opt.item_selected.is_connected(_on_character_changed):
+		opt.item_selected.disconnect(_on_character_changed)
+	opt.clear()
+	if _heroes.is_empty():
+		opt.add_item("gareth_ironshield", 0)
+		opt.set_item_metadata(0, "gareth_ironshield")
+	else:
+		var i := 0
+		for cid in _heroes.keys():
+			opt.add_item(str(cid), i)
+			opt.set_item_metadata(i, cid)
+			i += 1
+	if not opt.item_selected.is_connected(_on_character_changed):
+		opt.item_selected.connect(_on_character_changed)
+
+
+func _on_character_changed(_index: int) -> void:
+	_refresh_equipped()
+	_clear_detail()
+
+
+func _refresh_equipped() -> void:
+	var cid := _current_character_id()
+	var hero: Dictionary = _heroes.get(cid, {})
+	var eq: Dictionary = hero.get("equipment", {})
+	var lines: PackedStringArray = ["[%s 장착]" % cid]
+	for slot in ["weapon", "armor", "accessory", "trinket"]:
+		var iid: String = str(eq.get(slot, ""))
+		if iid.is_empty():
+			lines.append("  %s: (비어 있음)" % slot)
+		else:
+			lines.append("  %s: %s" % [slot, _label_for(iid)])
+	$VBox/EquippedLabel.text = "\n".join(lines)
+
+
+func _refresh_lists() -> void:
+	var owned_list: ItemList = $VBox/OwnedList
+	var cons_list: ItemList = $VBox/ConsumableList
+	owned_list.clear()
+	cons_list.clear()
+	for iid in _owned_ids:
+		var idx := owned_list.add_item(_label_for(str(iid)))
+		owned_list.set_item_metadata(idx, str(iid))
+	for iid in _consumables.keys():
+		var cnt: int = int(_consumables[iid])
+		var idx := cons_list.add_item("%s x%d" % [_label_for(str(iid)), cnt])
+		cons_list.set_item_metadata(idx, str(iid))
+	if owned_list.item_selected.is_connected(_on_owned_selected):
+		owned_list.item_selected.disconnect(_on_owned_selected)
+	if cons_list.item_selected.is_connected(_on_consumable_selected):
+		cons_list.item_selected.disconnect(_on_consumable_selected)
+	owned_list.item_selected.connect(_on_owned_selected)
+	cons_list.item_selected.connect(_on_consumable_selected)
+
+
+func _label_for(item_id: String) -> String:
+	if _item_cache.has(item_id):
+		var it: Dictionary = _item_cache[item_id]
+		return "%s %s" % [it.get("icon", "📦"), it.get("label", item_id)]
+	return item_id
+
+
+func _on_owned_selected(index: int) -> void:
+	if index < 0:
+		return
+	_selected_item_id = str($VBox/OwnedList.get_item_metadata(index))
+	_show_item_actions(true, false)
+
+
+func _on_consumable_selected(index: int) -> void:
+	if index < 0:
+		return
+	_selected_item_id = str($VBox/ConsumableList.get_item_metadata(index))
+	_show_item_actions(false, true)
+
+
+func _show_item_actions(can_equip: bool, can_use: bool) -> void:
+	$VBox/ActionRow/EquipButton.disabled = not can_equip
+	$VBox/ActionRow/UseButton.disabled = not can_use
+	if _selected_item_id.is_empty():
+		$VBox/DetailLabel.text = ""
+		return
+	var it: Dictionary = _item_cache.get(_selected_item_id, {})
+	if it.is_empty():
+		it = await ApiClient.fetch_item_detail(_selected_item_id)
+		if not it.is_empty():
+			_item_cache[_selected_item_id] = it
+	_render_detail(it)
+
+
+func _render_detail(it: Dictionary) -> void:
+	if it.is_empty():
+		$VBox/DetailLabel.text = _selected_item_id
+		return
+	var lines: PackedStringArray = [
+		"%s %s" % [it.get("icon", "📦"), it.get("label", _selected_item_id)],
+		"등급: %s · %s" % [it.get("grade_label", it.get("grade", "?")), it.get("category", "")],
+	]
+	if it.get("description"):
+		lines.append(str(it.get("description")))
+	$VBox/DetailLabel.text = "\n".join(lines)
+
+
+func _clear_detail() -> void:
+	_selected_item_id = ""
+	$VBox/DetailLabel.text = ""
+	$VBox/ActionRow/EquipButton.disabled = true
+	$VBox/ActionRow/UseButton.disabled = true
+
+
+func _on_equip_pressed() -> void:
+	if _selected_item_id.is_empty():
+		return
+	var cid := _current_character_id()
+	var result: Dictionary = await ApiClient.equip_item(cid, _selected_item_id)
+	if result.get("ok", false) or result.has("slot"):
+		$VBox/StatusLabel.text = "착용: %s → %s" % [_selected_item_id, result.get("slot", "?")]
+		var status: Dictionary = await ApiClient.fetch_progression_status()
+		_heroes = status.get("heroes", {})
+		_refresh_equipped()
+	else:
+		$VBox/StatusLabel.text = "착용 실패: %s" % result.get("error", "unknown")
+
+
+func _on_use_pressed() -> void:
+	if _selected_item_id.is_empty():
+		return
+	var cid := _current_character_id()
+	var result: Dictionary = await ApiClient.use_item(cid, _selected_item_id)
+	if result.get("ok", false):
+		$VBox/StatusLabel.text = "사용: %s · 효과 %s" % [
+			result.get("label", _selected_item_id),
+			str(result.get("effects", {})),
+		]
+		await _reload_all()
+	else:
+		$VBox/StatusLabel.text = "사용 실패: %s" % result.get("error", "unknown")
+
+
+func _on_starter_pack_pressed() -> void:
+	$VBox/StatusLabel.text = "시작 패키지 지급 중…"
+	var pack := [
+		["iron_sword", 1],
+		["leather_vest", 1],
+		["minor_heal_potion", 3],
+		["mana_potion", 2],
+	]
+	for entry in pack:
+		await ApiClient.grant_item(str(entry[0]), int(entry[1]))
+	await _reload_all()
+	$VBox/StatusLabel.text += " 완료"
+
+
+func _on_catalog_pressed() -> void:
+	get_tree().change_scene_to_file("res://scenes/item_catalog.tscn")
+
+
+func _on_back_pressed() -> void:
+	get_tree().change_scene_to_file("res://scenes/main_menu.tscn")
+
+
+func _on_api_error(message: String) -> void:
+	$VBox/StatusLabel.text += "\n[오류] %s" % message

--- a/fantasy_simulator/client/godot/scenes/inventory.tscn
+++ b/fantasy_simulator/client/godot/scenes/inventory.tscn
@@ -1,0 +1,106 @@
+[gd_scene load_steps=2 format=3 uid="uid://eldoria_inventory"]
+
+[ext_resource type="Script" path="res://scenes/inventory.gd" id="1_inv"]
+
+[node name="Inventory" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_inv")
+
+[node name="VBox" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 20.0
+offset_top = 16.0
+offset_right = -20.0
+offset_bottom = -16.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 8
+
+[node name="Title" type="Label" parent="VBox"]
+layout_mode = 2
+text = "인벤토리"
+horizontal_alignment = 1
+
+[node name="StatusLabel" type="Label" parent="VBox"]
+layout_mode = 2
+text = "—"
+
+[node name="CharacterOption" type="OptionButton" parent="VBox"]
+layout_mode = 2
+
+[node name="EquippedLabel" type="Label" parent="VBox"]
+layout_mode = 2
+text = "장착 —"
+
+[node name="ListsRow" type="HBoxContainer" parent="VBox"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_constants/separation = 12
+
+[node name="OwnedPanel" type="VBoxContainer" parent="VBox/ListsRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 4
+
+[node name="OwnedTitle" type="Label" parent="VBox/ListsRow/OwnedPanel"]
+layout_mode = 2
+text = "보유 장비"
+
+[node name="OwnedList" type="ItemList" parent="VBox/ListsRow/OwnedPanel"]
+custom_minimum_size = Vector2(0, 200)
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="ConsumablePanel" type="VBoxContainer" parent="VBox/ListsRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 4
+
+[node name="ConsumableTitle" type="Label" parent="VBox/ListsRow/ConsumablePanel"]
+layout_mode = 2
+text = "소비 아이템"
+
+[node name="ConsumableList" type="ItemList" parent="VBox/ListsRow/ConsumablePanel"]
+custom_minimum_size = Vector2(0, 200)
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="DetailLabel" type="TextEdit" parent="VBox"]
+custom_minimum_size = Vector2(0, 100)
+layout_mode = 2
+editable = false
+wrap_mode = 1
+
+[node name="ActionRow" type="HBoxContainer" parent="VBox"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="EquipButton" type="Button" parent="VBox/ActionRow"]
+layout_mode = 2
+disabled = true
+text = "착용"
+
+[node name="UseButton" type="Button" parent="VBox/ActionRow"]
+layout_mode = 2
+disabled = true
+text = "사용"
+
+[node name="StarterPackButton" type="Button" parent="VBox/ActionRow"]
+layout_mode = 2
+text = "시작 패키지 지급"
+
+[node name="CatalogButton" type="Button" parent="VBox"]
+layout_mode = 2
+text = "아이템 도감"
+
+[node name="BackButton" type="Button" parent="VBox"]
+layout_mode = 2
+text = "메인 메뉴"

--- a/fantasy_simulator/client/godot/scenes/item_catalog.gd
+++ b/fantasy_simulator/client/godot/scenes/item_catalog.gd
@@ -1,0 +1,152 @@
+extends Control
+
+const CATEGORIES := [
+	{"id": "", "label": "전체"},
+	{"id": "weapon", "label": "무기"},
+	{"id": "armor", "label": "방어구"},
+	{"id": "accessory", "label": "장신구"},
+	{"id": "potion", "label": "물약"},
+	{"id": "magic", "label": "마법"},
+	{"id": "material", "label": "재료"},
+]
+
+var _items: Array = []
+var _load_token: int = 0
+
+
+func _ready() -> void:
+	ApiClient.api_error.connect(_on_api_error)
+	$VBox/BackButton.pressed.connect(_on_back_pressed)
+	$VBox/RefreshButton.pressed.connect(_on_refresh_pressed)
+	$VBox/OpenInventoryButton.pressed.connect(_on_open_inventory_pressed)
+	_populate_category_filter()
+	if ApiClient.session_id.is_empty():
+		$VBox/StatusLabel.text = "세션이 없습니다. 메인 메뉴에서 새 게임을 시작하세요."
+		return
+	await _load_catalog()
+
+
+func _populate_category_filter() -> void:
+	var opt: OptionButton = $VBox/FilterRow/CategoryOption
+	opt.clear()
+	for i in CATEGORIES.size():
+		opt.add_item(CATEGORIES[i]["label"], i)
+		opt.set_item_metadata(i, CATEGORIES[i]["id"])
+	opt.item_selected.connect(_on_filter_changed)
+	$VBox/FilterRow/SearchBox.text_submitted.connect(_on_search_submitted)
+
+
+func _on_filter_changed(_index: int) -> void:
+	_load_catalog()
+
+
+func _on_search_submitted(_text: String) -> void:
+	_load_catalog()
+
+
+func _on_refresh_pressed() -> void:
+	await _load_catalog()
+
+
+func _load_catalog() -> void:
+	_load_token += 1
+	var token := _load_token
+	$VBox/StatusLabel.text = "도감 불러오는 중…"
+	var cat_idx: int = $VBox/FilterRow/CategoryOption.selected
+	if cat_idx < 0:
+		cat_idx = 0
+	var category: String = str($VBox/FilterRow/CategoryOption.get_item_metadata(cat_idx))
+	var search: String = $VBox/FilterRow/SearchBox.text.strip_edges()
+	var payload: Dictionary = await ApiClient.fetch_item_catalog(category, "", search, 300)
+	if token != _load_token:
+		return
+	if payload.is_empty():
+		$VBox/StatusLabel.text = "도감을 불러오지 못했습니다."
+		return
+	var counts: Dictionary = payload.get("counts", {})
+	_items = payload.get("items", [])
+	$VBox/StatusLabel.text = "총 %s종 · 표시 %s개" % [
+		counts.get("total", "?"),
+		payload.get("filtered_count", _items.size()),
+	]
+	_fill_item_list()
+
+
+func _fill_item_list() -> void:
+	var list: ItemList = $VBox/ItemList
+	list.clear()
+	for it in _items:
+		if not it is Dictionary:
+			continue
+		var icon := str(it.get("icon", "📦"))
+		var label := str(it.get("label", it.get("item_id", "?")))
+		var grade := str(it.get("grade_label", it.get("grade", "")))
+		var cat := str(it.get("category", ""))
+		var idx := list.add_item("%s %s [%s·%s]" % [icon, label, grade, cat])
+		list.set_item_metadata(idx, it.get("item_id", ""))
+
+
+func _on_item_selected(index: int) -> void:
+	if index < 0:
+		return
+	var list: ItemList = $VBox/ItemList
+	var item_id: String = str(list.get_item_metadata(index))
+	var it: Dictionary = _find_item(item_id)
+	if it.is_empty():
+		var detail: Dictionary = await ApiClient.fetch_item_detail(item_id)
+		it = detail
+	_render_detail(it)
+
+
+func _find_item(item_id: String) -> Dictionary:
+	for it in _items:
+		if it is Dictionary and str(it.get("item_id", "")) == item_id:
+			return it
+	return {}
+
+
+func _render_detail(it: Dictionary) -> void:
+	if it.is_empty():
+		$VBox/DetailLabel.text = "항목을 선택하세요."
+		return
+	var lines: PackedStringArray = []
+	lines.append("%s %s" % [it.get("icon", "📦"), it.get("label", "?")])
+	lines.append("ID: %s" % it.get("item_id", ""))
+	lines.append("분류: %s · 등급: %s (%s)" % [
+		it.get("category", "?"),
+		it.get("grade_label", it.get("grade", "?")),
+		it.get("rarity_color", ""),
+	])
+	if it.get("description"):
+		lines.append("")
+		lines.append(str(it.get("description")))
+	lines.append("")
+	if it.get("attack"):
+		lines.append("공격력: %s" % it.get("attack"))
+	if it.get("defense"):
+		lines.append("방어력: %s" % it.get("defense"))
+	if it.get("hp_restore"):
+		lines.append("HP 회복: %s" % it.get("hp_restore"))
+	if it.get("mp_restore"):
+		lines.append("MP 회복: %s" % it.get("mp_restore"))
+	if it.get("value_gold"):
+		lines.append("가치: %s 골드" % it.get("value_gold"))
+	if it.get("equippable"):
+		lines.append("착용 가능 슬롯: %s" % it.get("slot", "weapon"))
+	if it.get("consumable"):
+		lines.append("소비 아이템")
+	lines.append("")
+	lines.append("인벤토리에서 착용/사용하세요.")
+	$VBox/DetailLabel.text = "\n".join(lines)
+
+
+func _on_open_inventory_pressed() -> void:
+	get_tree().change_scene_to_file("res://scenes/inventory.tscn")
+
+
+func _on_back_pressed() -> void:
+	get_tree().change_scene_to_file("res://scenes/main_menu.tscn")
+
+
+func _on_api_error(message: String) -> void:
+	$VBox/StatusLabel.text += "\n[오류] %s" % message

--- a/fantasy_simulator/client/godot/scenes/item_catalog.tscn
+++ b/fantasy_simulator/client/godot/scenes/item_catalog.tscn
@@ -1,0 +1,72 @@
+[gd_scene load_steps=2 format=3 uid="uid://eldoria_item_catalog"]
+
+[ext_resource type="Script" path="res://scenes/item_catalog.gd" id="1_cat"]
+
+[node name="ItemCatalog" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_cat")
+
+[node name="VBox" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 20.0
+offset_top = 16.0
+offset_right = -20.0
+offset_bottom = -16.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 8
+
+[node name="Title" type="Label" parent="VBox"]
+layout_mode = 2
+text = "아이템 도감 (API)"
+horizontal_alignment = 1
+
+[node name="StatusLabel" type="Label" parent="VBox"]
+layout_mode = 2
+text = "—"
+
+[node name="FilterRow" type="HBoxContainer" parent="VBox"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="CategoryOption" type="OptionButton" parent="VBox/FilterRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="SearchBox" type="LineEdit" parent="VBox/FilterRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+placeholder_text = "이름 검색…"
+
+[node name="RefreshButton" type="Button" parent="VBox/FilterRow"]
+layout_mode = 2
+text = "새로고침"
+
+[node name="ItemList" type="ItemList" parent="VBox"]
+custom_minimum_size = Vector2(0, 280)
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="DetailLabel" type="TextEdit" parent="VBox"]
+custom_minimum_size = Vector2(0, 180)
+layout_mode = 2
+editable = false
+wrap_mode = 1
+
+[node name="OpenInventoryButton" type="Button" parent="VBox"]
+layout_mode = 2
+text = "인벤토리 열기"
+
+[node name="BackButton" type="Button" parent="VBox"]
+layout_mode = 2
+text = "메인 메뉴"
+
+[connection signal="item_selected" from="VBox/ItemList" to="." method="_on_item_selected"]

--- a/fantasy_simulator/client/godot/scenes/main_menu.gd
+++ b/fantasy_simulator/client/godot/scenes/main_menu.gd
@@ -63,6 +63,18 @@ func _on_skill_tree_pressed() -> void:
 	get_tree().change_scene_to_file("res://scenes/skill_tree.tscn")
 
 
+func _on_inventory_pressed() -> void:
+	if _session_busy or ApiClient.session_id.is_empty():
+		return
+	get_tree().change_scene_to_file("res://scenes/inventory.tscn")
+
+
+func _on_catalog_pressed() -> void:
+	if _session_busy or ApiClient.session_id.is_empty():
+		return
+	get_tree().change_scene_to_file("res://scenes/item_catalog.tscn")
+
+
 func _on_turn_completed(payload: Dictionary) -> void:
 	for line in payload.get("lines", []):
 		$VBox/Narrative.text += str(line) + "\n"
@@ -85,3 +97,5 @@ func _set_play_buttons(enabled: bool) -> void:
 	$VBox/ExploreButton.disabled = not enabled
 	$VBox/Explore2DButton.disabled = not enabled
 	$VBox/SkillTreeButton.disabled = not enabled
+	$VBox/InventoryButton.disabled = not enabled
+	$VBox/CatalogButton.disabled = not enabled

--- a/fantasy_simulator/client/godot/scenes/main_menu.tscn
+++ b/fantasy_simulator/client/godot/scenes/main_menu.tscn
@@ -55,6 +55,16 @@ layout_mode = 2
 disabled = true
 text = "스킬 트리 (Lv999)"
 
+[node name="InventoryButton" type="Button" parent="VBox"]
+layout_mode = 2
+disabled = true
+text = "인벤토리"
+
+[node name="CatalogButton" type="Button" parent="VBox"]
+layout_mode = 2
+disabled = true
+text = "아이템 도감"
+
 [node name="Hud" type="Label" parent="VBox"]
 layout_mode = 2
 text = "—"
@@ -69,3 +79,5 @@ wrap_mode = 1
 [connection signal="pressed" from="VBox/ExploreButton" to="." method="_on_explore_pressed"]
 [connection signal="pressed" from="VBox/Explore2DButton" to="." method="_on_explore_2d_pressed"]
 [connection signal="pressed" from="VBox/SkillTreeButton" to="." method="_on_skill_tree_pressed"]
+[connection signal="pressed" from="VBox/InventoryButton" to="." method="_on_inventory_pressed"]
+[connection signal="pressed" from="VBox/CatalogButton" to="." method="_on_catalog_pressed"]

--- a/fantasy_simulator/client/godot/scripts/net/api_client.gd
+++ b/fantasy_simulator/client/godot/scripts/net/api_client.gd
@@ -168,6 +168,47 @@ func fetch_item_catalog(
 	return parsed if parsed != null else {}
 
 
+func equip_item(character_id: String, item_id: String) -> Dictionary:
+	if session_id.is_empty():
+		api_error.emit("no session")
+		return {}
+	var parsed := await _post_json(
+		"/v1/progression/equip",
+		{
+			"session_id": session_id,
+			"character_id": character_id,
+			"item_id": item_id,
+		},
+	)
+	return parsed if parsed != null else {}
+
+
+func grant_item(item_id: String, count: int = 1) -> Dictionary:
+	if session_id.is_empty():
+		api_error.emit("no session")
+		return {}
+	var parsed := await _post_json(
+		"/v1/progression/grant_item",
+		{
+			"session_id": session_id,
+			"item_id": item_id,
+			"count": count,
+		},
+	)
+	return parsed if parsed != null else {}
+
+
+func fetch_item_detail(item_id: String) -> Dictionary:
+	var parsed := await _post_json(
+		"/v1/catalog/items/%s" % item_id.uri_encode(),
+		{},
+		HTTPClient.METHOD_GET,
+	)
+	if parsed == null:
+		return {}
+	return parsed.get("item", {})
+
+
 func use_item(character_id: String, item_id: String) -> Dictionary:
 	if session_id.is_empty():
 		api_error.emit("no session")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Godot client screens for the unified item catalog API.

### New scenes
- `scenes/item_catalog.tscn` — browse/filter 213+ items (category, search, detail)
- `scenes/inventory.tscn` — per-hero equipped slots, owned gear, consumables

### Actions
- **착용** → `POST /v1/progression/equip`
- **사용** → `POST /v1/progression/use_item`
- **시작 패키지 지급** → grant iron_sword, leather_vest, potions (dev helper)

### Navigation
- Main menu: 인벤토리 / 아이템 도감 buttons
- Exploration HUD: 인벤 / 도감 shortcuts
- Cross-link between catalog ↔ inventory

### ApiClient
- `equip_item`, `grant_item`, `fetch_item_detail`

Requires API server on :8765 and hybrid session (new game).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d47ad9e-531c-4119-8aaf-f35fd4e3e3ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d47ad9e-531c-4119-8aaf-f35fd4e3e3ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

