### PR TITLE
Polish Godot item catalog & inventory UI (fix catalog not loading)

### DIFF
--- a/fantasy_simulator/client/godot/scenes/inventory.gd
+++ b/fantasy_simulator/client/godot/scenes/inventory.gd
@@ -1,38 +1,78 @@
 extends Control
 
+const ItemUiTheme = preload("res://scripts/ui/item_ui_theme.gd")
+
+@onready var _owned_list: ItemList = $Root/Margin/VBox/Body/OwnedPanel/Margin/VBox/List
+@onready var _cons_list: ItemList = $Root/Margin/VBox/Body/ConsumablePanel/Margin/VBox/List
+@onready var _detail: RichTextLabel = $Root/Margin/VBox/DetailPanel/Margin/Detail
+@onready var _status: Label = $Root/Margin/VBox/StatusLabel
+@onready var _count_label: Label = $Root/Margin/VBox/Header/CountLabel
+@onready var _equipped: RichTextLabel = $Root/Margin/VBox/EquippedPanel/Margin/Equipped
+@onready var _char_opt: OptionButton = $Root/Margin/VBox/CharRow/CharacterOption
+
 var _heroes: Dictionary = {}
 var _inventory: Dictionary = {}
 var _owned_ids: Array = []
 var _consumables: Dictionary = {}
 var _selected_item_id: String = ""
 var _item_cache: Dictionary = {}
+var _can_equip: bool = false
+var _can_use: bool = false
 
 
 func _ready() -> void:
 	ApiClient.api_error.connect(_on_api_error)
-	$VBox/BackButton.pressed.connect(_on_back_pressed)
-	$VBox/CatalogButton.pressed.connect(_on_catalog_pressed)
-	$VBox/ActionRow/EquipButton.pressed.connect(_on_equip_pressed)
-	$VBox/ActionRow/UseButton.pressed.connect(_on_use_pressed)
-	$VBox/ActionRow/StarterPackButton.pressed.connect(_on_starter_pack_pressed)
+	_owned_list.item_selected.connect(_on_owned_selected)
+	_owned_list.item_activated.connect(_on_owned_selected)
+	_cons_list.item_selected.connect(_on_consumable_selected)
+	_cons_list.item_activated.connect(_on_consumable_selected)
+	$Root/Margin/VBox/Header/BackButton.pressed.connect(_on_back_pressed)
+	$Root/Margin/VBox/Header/CatalogButton.pressed.connect(_on_catalog_pressed)
+	$Root/Margin/VBox/Header/RefreshButton.pressed.connect(func(): await _reload_all())
+	$Root/Margin/VBox/Actions/EquipButton.pressed.connect(_on_equip_pressed)
+	$Root/Margin/VBox/Actions/UseButton.pressed.connect(_on_use_pressed)
+	$Root/Margin/VBox/Actions/StarterPackButton.pressed.connect(_on_starter_pack_pressed)
+	_apply_list_theme(_owned_list)
+	_apply_list_theme(_cons_list)
+	_style_panels()
 	if ApiClient.session_id.is_empty():
-		$VBox/StatusLabel.text = "세션이 없습니다. 메인 메뉴에서 새 게임을 시작하세요."
+		_status.text = "세션이 없습니다. 메인 메뉴에서 새 게임을 시작하세요."
 		return
 	await _reload_all()
 
 
+func _style_panels() -> void:
+	for node_name in ["OwnedPanel", "ConsumablePanel", "DetailPanel", "EquippedPanel"]:
+		var panel: PanelContainer = get_node_or_null("Root/Margin/VBox/Body/" + node_name)
+		if panel == null:
+			panel = get_node_or_null("Root/Margin/VBox/" + node_name)
+		if panel:
+			panel.add_theme_stylebox_override("panel", ItemUiTheme.panel_style())
+
+
+func _apply_list_theme(list: ItemList) -> void:
+	var sb := StyleBoxFlat.new()
+	sb.bg_color = ItemUiTheme.PANEL.lightened(0.05)
+	sb.set_corner_radius_all(8)
+	sb.content_margin_left = 10
+	sb.content_margin_right = 10
+	sb.content_margin_top = 6
+	sb.content_margin_bottom = 6
+	list.add_theme_stylebox_override("panel", sb)
+	list.add_theme_font_size_override("font_size", 14)
+
+
 func _current_character_id() -> String:
-	var opt: OptionButton = $VBox/CharacterOption
-	if opt.item_count == 0:
+	if _char_opt.item_count == 0:
 		return "gareth_ironshield"
-	var sel := opt.selected
+	var sel := _char_opt.selected
 	if sel < 0:
 		sel = 0
-	return str(opt.get_item_metadata(sel))
+	return str(_char_opt.get_item_metadata(sel))
 
 
 func _reload_all() -> void:
-	$VBox/StatusLabel.text = "인벤토리 불러오는 중…"
+	_status.text = "인벤토리 불러오는 중..."
 	var status: Dictionary = await ApiClient.fetch_progression_status()
 	var catalog: Dictionary = await ApiClient.fetch_item_catalog("", "", "", 500)
 	_heroes = status.get("heroes", {})
@@ -47,29 +87,25 @@ func _reload_all() -> void:
 	_refresh_lists()
 	_refresh_equipped()
 	var total_items := int(catalog.get("counts", {}).get("total", 0))
-	$VBox/StatusLabel.text = "도감 %s종 · 보유 장비 %d · 소비 %d" % [
-		total_items,
-		_owned_ids.size(),
-		_consumables.size(),
-	]
+	_count_label.text = "도감 %d종" % total_items
+	_status.text = "보유 장비 %d · 소비 %d종" % [_owned_ids.size(), _consumables.size()]
 
 
 func _populate_characters() -> void:
-	var opt: OptionButton = $VBox/CharacterOption
-	if opt.item_selected.is_connected(_on_character_changed):
-		opt.item_selected.disconnect(_on_character_changed)
-	opt.clear()
+	if _char_opt.item_selected.is_connected(_on_character_changed):
+		_char_opt.item_selected.disconnect(_on_character_changed)
+	_char_opt.clear()
 	if _heroes.is_empty():
-		opt.add_item("gareth_ironshield", 0)
-		opt.set_item_metadata(0, "gareth_ironshield")
+		_char_opt.add_item("gareth_ironshield", 0)
+		_char_opt.set_item_metadata(0, "gareth_ironshield")
 	else:
 		var i := 0
 		for cid in _heroes.keys():
-			opt.add_item(str(cid), i)
-			opt.set_item_metadata(i, cid)
+			_char_opt.add_item(str(cid), i)
+			_char_opt.set_item_metadata(i, cid)
 			i += 1
-	if not opt.item_selected.is_connected(_on_character_changed):
-		opt.item_selected.connect(_on_character_changed)
+	if not _char_opt.item_selected.is_connected(_on_character_changed):
+		_char_opt.item_selected.connect(_on_character_changed)
 
 
 func _on_character_changed(_index: int) -> void:
@@ -81,122 +117,120 @@ func _refresh_equipped() -> void:
 	var cid := _current_character_id()
 	var hero: Dictionary = _heroes.get(cid, {})
 	var eq: Dictionary = hero.get("equipment", {})
-	var lines: PackedStringArray = ["[%s 장착]" % cid]
+	var lines: PackedStringArray = []
+	lines.append("[color=#c9a84c][b]%s 장착[/b][/color]" % cid)
 	for slot in ["weapon", "armor", "accessory", "trinket"]:
 		var iid: String = str(eq.get(slot, ""))
 		if iid.is_empty():
-			lines.append("  %s: (비어 있음)" % slot)
+			lines.append("  [color=#666]%s[/color]: (비어 있음)" % slot)
 		else:
-			lines.append("  %s: %s" % [slot, _label_for(iid)])
-	$VBox/EquippedLabel.text = "\n".join(lines)
+			var it: Dictionary = _item_cache.get(iid, {})
+			var col := ItemUiTheme.grade_color(str(it.get("grade", "common"))).to_html(false)
+			lines.append(
+				"  %s: [color=%s]%s %s[/color]"
+				% [slot, col, it.get("icon", "📦"), it.get("label", iid)]
+			)
+	_equipped.text = "\n".join(lines)
 
 
 func _refresh_lists() -> void:
-	var owned_list: ItemList = $VBox/OwnedList
-	var cons_list: ItemList = $VBox/ConsumableList
-	owned_list.clear()
-	cons_list.clear()
+	_owned_list.clear()
+	_cons_list.clear()
 	for iid in _owned_ids:
-		var idx := owned_list.add_item(_label_for(str(iid)))
-		owned_list.set_item_metadata(idx, str(iid))
+		var it: Dictionary = _item_cache.get(str(iid), {})
+		var grade: String = str(it.get("grade", "common"))
+		var idx := _owned_list.add_item(_label_for(str(iid)))
+		_owned_list.set_item_metadata(idx, str(iid))
+		_owned_list.set_item_custom_fg_color(idx, ItemUiTheme.grade_color(grade))
 	for iid in _consumables.keys():
+		var it: Dictionary = _item_cache.get(str(iid), {})
+		var grade: String = str(it.get("grade", "common"))
 		var cnt: int = int(_consumables[iid])
-		var idx := cons_list.add_item("%s x%d" % [_label_for(str(iid)), cnt])
-		cons_list.set_item_metadata(idx, str(iid))
-	if owned_list.item_selected.is_connected(_on_owned_selected):
-		owned_list.item_selected.disconnect(_on_owned_selected)
-	if cons_list.item_selected.is_connected(_on_consumable_selected):
-		cons_list.item_selected.disconnect(_on_consumable_selected)
-	owned_list.item_selected.connect(_on_owned_selected)
-	cons_list.item_selected.connect(_on_consumable_selected)
+		var idx := _cons_list.add_item("%s x%d" % [_label_for(str(iid)), cnt])
+		_cons_list.set_item_metadata(idx, str(iid))
+		_cons_list.set_item_custom_fg_color(idx, ItemUiTheme.grade_color(grade))
 
 
 func _label_for(item_id: String) -> String:
 	if _item_cache.has(item_id):
 		var it: Dictionary = _item_cache[item_id]
-		return "%s %s" % [it.get("icon", "📦"), it.get("label", item_id)]
+		var grade_txt := str(it.get("grade_label", ItemUiTheme.grade_label(str(it.get("grade", "")))))
+		return "%s %s [%s]" % [it.get("icon", "📦"), it.get("label", item_id), grade_txt]
 	return item_id
 
 
 func _on_owned_selected(index: int) -> void:
 	if index < 0:
 		return
-	_selected_item_id = str($VBox/OwnedList.get_item_metadata(index))
+	_selected_item_id = str(_owned_list.get_item_metadata(index))
 	_show_item_actions(true, false)
 
 
 func _on_consumable_selected(index: int) -> void:
 	if index < 0:
 		return
-	_selected_item_id = str($VBox/ConsumableList.get_item_metadata(index))
+	_selected_item_id = str(_cons_list.get_item_metadata(index))
 	_show_item_actions(false, true)
 
 
 func _show_item_actions(can_equip: bool, can_use: bool) -> void:
-	$VBox/ActionRow/EquipButton.disabled = not can_equip
-	$VBox/ActionRow/UseButton.disabled = not can_use
+	_can_equip = can_equip
+	_can_use = can_use
+	$Root/Margin/VBox/Actions/EquipButton.disabled = not can_equip
+	$Root/Margin/VBox/Actions/UseButton.disabled = not can_use
 	if _selected_item_id.is_empty():
-		$VBox/DetailLabel.text = ""
+		_detail.text = ""
 		return
 	var it: Dictionary = _item_cache.get(_selected_item_id, {})
 	if it.is_empty():
 		it = await ApiClient.fetch_item_detail(_selected_item_id)
 		if not it.is_empty():
 			_item_cache[_selected_item_id] = it
-	_render_detail(it)
-
-
-func _render_detail(it: Dictionary) -> void:
-	if it.is_empty():
-		$VBox/DetailLabel.text = _selected_item_id
-		return
-	var lines: PackedStringArray = [
-		"%s %s" % [it.get("icon", "📦"), it.get("label", _selected_item_id)],
-		"등급: %s · %s" % [it.get("grade_label", it.get("grade", "?")), it.get("category", "")],
-	]
-	if it.get("description"):
-		lines.append(str(it.get("description")))
-	$VBox/DetailLabel.text = "\n".join(lines)
+	if can_use and _consumables.has(_selected_item_id):
+		it = it.duplicate(true)
+		it["quantity"] = _consumables[_selected_item_id]
+	_detail.text = ItemUiTheme.detail_bbcode(it)
 
 
 func _clear_detail() -> void:
 	_selected_item_id = ""
-	$VBox/DetailLabel.text = ""
-	$VBox/ActionRow/EquipButton.disabled = true
-	$VBox/ActionRow/UseButton.disabled = true
+	_detail.text = ""
+	_can_equip = false
+	_can_use = false
+	$Root/Margin/VBox/Actions/EquipButton.disabled = true
+	$Root/Margin/VBox/Actions/UseButton.disabled = true
 
 
 func _on_equip_pressed() -> void:
 	if _selected_item_id.is_empty():
 		return
 	var cid := _current_character_id()
+	_status.text = "장착 중..."
 	var result: Dictionary = await ApiClient.equip_item(cid, _selected_item_id)
 	if result.get("ok", false) or result.has("slot"):
-		$VBox/StatusLabel.text = "착용: %s → %s" % [_selected_item_id, result.get("slot", "?")]
+		_status.text = "착용 완료: %s → %s" % [_selected_item_id, result.get("slot", "?")]
 		var status: Dictionary = await ApiClient.fetch_progression_status()
 		_heroes = status.get("heroes", {})
 		_refresh_equipped()
 	else:
-		$VBox/StatusLabel.text = "착용 실패: %s" % result.get("error", "unknown")
+		_status.text = "착용 실패: %s" % result.get("error", "unknown")
 
 
 func _on_use_pressed() -> void:
 	if _selected_item_id.is_empty():
 		return
 	var cid := _current_character_id()
+	_status.text = "사용 중..."
 	var result: Dictionary = await ApiClient.use_item(cid, _selected_item_id)
 	if result.get("ok", false):
-		$VBox/StatusLabel.text = "사용: %s · 효과 %s" % [
-			result.get("label", _selected_item_id),
-			str(result.get("effects", {})),
-		]
+		_status.text = "사용 완료: %s" % result.get("label", _selected_item_id)
 		await _reload_all()
 	else:
-		$VBox/StatusLabel.text = "사용 실패: %s" % result.get("error", "unknown")
+		_status.text = "사용 실패: %s" % result.get("error", "unknown")
 
 
 func _on_starter_pack_pressed() -> void:
-	$VBox/StatusLabel.text = "시작 패키지 지급 중…"
+	_status.text = "시작 패키지 지급 중..."
 	var pack := [
 		["iron_sword", 1],
 		["leather_vest", 1],
@@ -206,7 +240,7 @@ func _on_starter_pack_pressed() -> void:
 	for entry in pack:
 		await ApiClient.grant_item(str(entry[0]), int(entry[1]))
 	await _reload_all()
-	$VBox/StatusLabel.text += " 완료"
+	_status.text += " 완료"
 
 
 func _on_catalog_pressed() -> void:
@@ -218,4 +252,4 @@ func _on_back_pressed() -> void:
 
 
 func _on_api_error(message: String) -> void:
-	$VBox/StatusLabel.text += "\n[오류] %s" % message
+	_status.text += "\n[오류] %s" % message

--- a/fantasy_simulator/client/godot/scenes/inventory.tscn
+++ b/fantasy_simulator/client/godot/scenes/inventory.tscn
@@ -1,6 +1,6 @@
-[gd_scene load_steps=2 format=3 uid="uid://eldoria_inventory"]
+[gd_scene load_steps=2 format=3 uid="uid://inventory_scene"]
 
-[ext_resource type="Script" path="res://scenes/inventory.gd" id="1_inv"]
+[ext_resource type="Script" path="res://scenes/inventory.gd" id="1"]
 
 [node name="Inventory" type="Control"]
 layout_mode = 3
@@ -9,98 +9,206 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-script = ExtResource("1_inv")
+script = ExtResource("1")
 
-[node name="VBox" type="VBoxContainer" parent="."]
+[node name="Root" type="ColorRect" parent="."]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 20.0
-offset_top = 16.0
-offset_right = -20.0
-offset_bottom = -16.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_constants/separation = 8
+color = Color(0.043, 0.059, 0.102, 1)
 
-[node name="Title" type="Label" parent="VBox"]
+[node name="Margin" type="MarginContainer" parent="Root"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 16
+
+[node name="VBox" type="VBoxContainer" parent="Root/Margin"]
 layout_mode = 2
-text = "인벤토리"
+theme_override_constants/separation = 10
+
+[node name="Header" type="HBoxContainer" parent="Root/Margin/VBox"]
+layout_mode = 2
+
+[node name="BackButton" type="Button" parent="Root/Margin/VBox/Header"]
+custom_minimum_size = Vector2(88, 40)
+layout_mode = 2
+text = "← 메뉴"
+
+[node name="Title" type="Label" parent="Root/Margin/VBox/Header"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_colors/font_color = Color(0.55, 0.82, 0.95, 1)
+theme_override_font_sizes/font_size = 28
+text = "🎒 인벤토리"
 horizontal_alignment = 1
 
-[node name="StatusLabel" type="Label" parent="VBox"]
+[node name="CountLabel" type="Label" parent="Root/Margin/VBox/Header"]
+custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
-text = "—"
+theme_override_colors/font_color = Color(0.55, 0.62, 0.78, 1)
+theme_override_font_sizes/font_size = 14
+text = "도감 0종"
+horizontal_alignment = 2
 
-[node name="CharacterOption" type="OptionButton" parent="VBox"]
+[node name="CatalogButton" type="Button" parent="Root/Margin/VBox/Header"]
+custom_minimum_size = Vector2(88, 40)
+layout_mode = 2
+text = "📖 도감"
+
+[node name="RefreshButton" type="Button" parent="Root/Margin/VBox/Header"]
+custom_minimum_size = Vector2(88, 40)
+layout_mode = 2
+text = "새로고침"
+
+[node name="CharRow" type="HBoxContainer" parent="Root/Margin/VBox"]
 layout_mode = 2
 
-[node name="EquippedLabel" type="Label" parent="VBox"]
+[node name="CharLabel" type="Label" parent="Root/Margin/VBox/CharRow"]
 layout_mode = 2
-text = "장착 —"
+theme_override_colors/font_color = Color(0.91, 0.78, 0.42, 1)
+theme_override_font_sizes/font_size = 15
+text = "캐릭터"
 
-[node name="ListsRow" type="HBoxContainer" parent="VBox"]
+[node name="CharacterOption" type="OptionButton" parent="Root/Margin/VBox/CharRow"]
+custom_minimum_size = Vector2(220, 36)
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Body" type="HBoxContainer" parent="Root/Margin/VBox"]
 layout_mode = 2
 size_flags_vertical = 3
+theme_override_constants/separation = 10
+
+[node name="OwnedPanel" type="PanelContainer" parent="Root/Margin/VBox/Body"]
+custom_minimum_size = Vector2(260, 0)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.35
+
+[node name="Margin" type="MarginContainer" parent="Root/Margin/VBox/Body/OwnedPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 6
+theme_override_constants/margin_top = 6
+theme_override_constants/margin_right = 6
+theme_override_constants/margin_bottom = 6
+
+[node name="VBox" type="VBoxContainer" parent="Root/Margin/VBox/Body/OwnedPanel/Margin"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Root/Margin/VBox/Body/OwnedPanel/Margin/VBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.78, 0.42, 1)
+theme_override_font_sizes/font_size = 14
+text = "⚔ 장비"
+
+[node name="List" type="ItemList" parent="Root/Margin/VBox/Body/OwnedPanel/Margin/VBox"]
+layout_mode = 2
+size_flags_vertical = 3
+allow_reselect = true
+
+[node name="ConsumablePanel" type="PanelContainer" parent="Root/Margin/VBox/Body"]
+custom_minimum_size = Vector2(260, 0)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.35
+
+[node name="Margin" type="MarginContainer" parent="Root/Margin/VBox/Body/ConsumablePanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 6
+theme_override_constants/margin_top = 6
+theme_override_constants/margin_right = 6
+theme_override_constants/margin_bottom = 6
+
+[node name="VBox" type="VBoxContainer" parent="Root/Margin/VBox/Body/ConsumablePanel/Margin"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Root/Margin/VBox/Body/ConsumablePanel/Margin/VBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.55, 0.82, 0.95, 1)
+theme_override_font_sizes/font_size = 14
+text = "🧪 소비품"
+
+[node name="List" type="ItemList" parent="Root/Margin/VBox/Body/ConsumablePanel/Margin/VBox"]
+layout_mode = 2
+size_flags_vertical = 3
+allow_reselect = true
+
+[node name="EquippedPanel" type="PanelContainer" parent="Root/Margin/VBox/Body"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.3
+
+[node name="Margin" type="MarginContainer" parent="Root/Margin/VBox/Body/EquippedPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 8
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 8
+
+[node name="Equipped" type="RichTextLabel" parent="Root/Margin/VBox/Body/EquippedPanel/Margin"]
+custom_minimum_size = Vector2(0, 120)
+layout_mode = 2
+size_flags_vertical = 3
+bbcode_enabled = true
+fit_content = true
+scroll_active = true
+
+[node name="DetailPanel" type="PanelContainer" parent="Root/Margin/VBox"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 160)
+
+[node name="Margin" type="MarginContainer" parent="Root/Margin/VBox/DetailPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 14
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 14
+theme_override_constants/margin_bottom = 10
+
+[node name="Detail" type="RichTextLabel" parent="Root/Margin/VBox/DetailPanel/Margin"]
+custom_minimum_size = Vector2(0, 140)
+layout_mode = 2
+size_flags_vertical = 3
+bbcode_enabled = true
+fit_content = true
+scroll_active = true
+
+[node name="Actions" type="HBoxContainer" parent="Root/Margin/VBox"]
+layout_mode = 2
 theme_override_constants/separation = 12
+alignment = 1
 
-[node name="OwnedPanel" type="VBoxContainer" parent="VBox/ListsRow"]
+[node name="EquipButton" type="Button" parent="Root/Margin/VBox/Actions"]
+custom_minimum_size = Vector2(120, 42)
 layout_mode = 2
-size_flags_horizontal = 3
-theme_override_constants/separation = 4
-
-[node name="OwnedTitle" type="Label" parent="VBox/ListsRow/OwnedPanel"]
-layout_mode = 2
-text = "보유 장비"
-
-[node name="OwnedList" type="ItemList" parent="VBox/ListsRow/OwnedPanel"]
-custom_minimum_size = Vector2(0, 200)
-layout_mode = 2
-size_flags_vertical = 3
-
-[node name="ConsumablePanel" type="VBoxContainer" parent="VBox/ListsRow"]
-layout_mode = 2
-size_flags_horizontal = 3
-theme_override_constants/separation = 4
-
-[node name="ConsumableTitle" type="Label" parent="VBox/ListsRow/ConsumablePanel"]
-layout_mode = 2
-text = "소비 아이템"
-
-[node name="ConsumableList" type="ItemList" parent="VBox/ListsRow/ConsumablePanel"]
-custom_minimum_size = Vector2(0, 200)
-layout_mode = 2
-size_flags_vertical = 3
-
-[node name="DetailLabel" type="TextEdit" parent="VBox"]
-custom_minimum_size = Vector2(0, 100)
-layout_mode = 2
-editable = false
-wrap_mode = 1
-
-[node name="ActionRow" type="HBoxContainer" parent="VBox"]
-layout_mode = 2
-theme_override_constants/separation = 8
-
-[node name="EquipButton" type="Button" parent="VBox/ActionRow"]
-layout_mode = 2
+theme_override_font_sizes/font_size = 15
 disabled = true
-text = "착용"
+text = "⚔ 장착"
 
-[node name="UseButton" type="Button" parent="VBox/ActionRow"]
+[node name="UseButton" type="Button" parent="Root/Margin/VBox/Actions"]
+custom_minimum_size = Vector2(120, 42)
 layout_mode = 2
+theme_override_font_sizes/font_size = 15
 disabled = true
-text = "사용"
+text = "✨ 사용"
 
-[node name="StarterPackButton" type="Button" parent="VBox/ActionRow"]
+[node name="StarterPackButton" type="Button" parent="Root/Margin/VBox/Actions"]
+custom_minimum_size = Vector2(150, 42)
 layout_mode = 2
-text = "시작 패키지 지급"
+theme_override_font_sizes/font_size = 14
+text = "🎁 시작 패키지"
 
-[node name="CatalogButton" type="Button" parent="VBox"]
+[node name="StatusLabel" type="Label" parent="Root/Margin/VBox"]
 layout_mode = 2
-text = "아이템 도감"
-
-[node name="BackButton" type="Button" parent="VBox"]
-layout_mode = 2
-text = "메인 메뉴"
+theme_override_colors/font_color = Color(0.45, 0.52, 0.65, 1)
+theme_override_font_sizes/font_size = 13
+text = "준비 중..."

--- a/fantasy_simulator/client/godot/scenes/item_catalog.gd
+++ b/fantasy_simulator/client/godot/scenes/item_catalog.gd
@@ -1,143 +1,185 @@
 extends Control
 
-const CATEGORIES := [
-	{"id": "", "label": "전체"},
-	{"id": "weapon", "label": "무기"},
-	{"id": "armor", "label": "방어구"},
-	{"id": "accessory", "label": "장신구"},
-	{"id": "potion", "label": "물약"},
-	{"id": "magic", "label": "마법"},
-	{"id": "material", "label": "재료"},
-]
+const ItemUiTheme = preload("res://scripts/ui/item_ui_theme.gd")
+
+@onready var _search: LineEdit = $Root/Margin/VBox/Toolbar/SearchRow/SearchEdit
+@onready var _count_label: Label = $Root/Margin/VBox/Header/CountLabel
+@onready var _list: ItemList = $Root/Margin/VBox/Body/ListPanel/Margin/List
+@onready var _detail: RichTextLabel = $Root/Margin/VBox/Body/DetailPanel/Margin/Detail
+@onready var _status: Label = $Root/Margin/VBox/StatusLabel
+@onready var _chip_row: HBoxContainer = $Root/Margin/VBox/Toolbar/ChipRow
 
 var _items: Array = []
-var _load_token: int = 0
+var _filtered: Array = []
+var _category_filter: String = "all"
+var _chip_buttons: Dictionary = {}
 
 
 func _ready() -> void:
 	ApiClient.api_error.connect(_on_api_error)
-	$VBox/BackButton.pressed.connect(_on_back_pressed)
-	$VBox/RefreshButton.pressed.connect(_on_refresh_pressed)
-	$VBox/OpenInventoryButton.pressed.connect(_on_open_inventory_pressed)
-	_populate_category_filter()
+	_search.text_changed.connect(_on_search_changed)
+	_list.item_selected.connect(_on_item_selected)
+	_list.item_activated.connect(_on_item_selected)
+	$Root/Margin/VBox/Toolbar/SearchRow/RefreshButton.pressed.connect(_load_catalog)
+	$Root/Margin/VBox/Header/BackButton.pressed.connect(_on_back_pressed)
+	$Root/Margin/VBox/Header/InventoryButton.pressed.connect(_on_open_inventory_pressed)
+	_build_category_chips()
+	_apply_list_theme()
+	_style_panels()
 	if ApiClient.session_id.is_empty():
-		$VBox/StatusLabel.text = "세션이 없습니다. 메인 메뉴에서 새 게임을 시작하세요."
+		_status.text = "세션이 없습니다. 메인 메뉴에서 새 게임을 시작하세요."
 		return
-	await _load_catalog()
-
-
-func _populate_category_filter() -> void:
-	var opt: OptionButton = $VBox/FilterRow/CategoryOption
-	opt.clear()
-	for i in CATEGORIES.size():
-		opt.add_item(CATEGORIES[i]["label"], i)
-		opt.set_item_metadata(i, CATEGORIES[i]["id"])
-	opt.item_selected.connect(_on_filter_changed)
-	$VBox/FilterRow/SearchBox.text_submitted.connect(_on_search_submitted)
-
-
-func _on_filter_changed(_index: int) -> void:
 	_load_catalog()
 
 
-func _on_search_submitted(_text: String) -> void:
-	_load_catalog()
+func _style_panels() -> void:
+	for panel_name in ["ListPanel", "DetailPanel"]:
+		var panel: PanelContainer = $Root/Margin/VBox/Body.get_node(panel_name)
+		panel.add_theme_stylebox_override("panel", ItemUiTheme.panel_style())
 
 
-func _on_refresh_pressed() -> void:
-	await _load_catalog()
+func _apply_list_theme() -> void:
+	var sb := StyleBoxFlat.new()
+	sb.bg_color = ItemUiTheme.PANEL.lightened(0.05)
+	sb.set_corner_radius_all(8)
+	sb.content_margin_left = 10
+	sb.content_margin_right = 10
+	sb.content_margin_top = 6
+	sb.content_margin_bottom = 6
+	_list.add_theme_stylebox_override("panel", sb)
+	_list.add_theme_font_size_override("font_size", 15)
+
+
+func _build_category_chips() -> void:
+	for child in _chip_row.get_children():
+		child.queue_free()
+	_chip_buttons.clear()
+
+	var categories: Array[String] = [
+		"all", "weapon", "armor", "accessory", "potion", "magic", "material"
+	]
+	var labels: Dictionary = {
+		"all": "전체",
+		"weapon": "무기",
+		"armor": "방어구",
+		"accessory": "장신구",
+		"potion": "포션",
+		"magic": "마법",
+		"material": "재료",
+	}
+	for cat in categories:
+		var btn := Button.new()
+		btn.text = labels.get(cat, cat)
+		btn.toggle_mode = true
+		btn.button_pressed = cat == "all"
+		btn.custom_minimum_size = Vector2(72, 34)
+		btn.add_theme_font_size_override("font_size", 13)
+		_style_chip(btn, cat == "all")
+		btn.pressed.connect(_on_chip_pressed.bind(cat, btn))
+		_chip_row.add_child(btn)
+		_chip_buttons[cat] = btn
+
+
+func _style_chip(btn: Button, active: bool) -> void:
+	var sb := StyleBoxFlat.new()
+	sb.set_corner_radius_all(16)
+	if active:
+		sb.bg_color = ItemUiTheme.ACCENT
+		btn.add_theme_color_override("font_color", Color.WHITE)
+	else:
+		sb.bg_color = ItemUiTheme.PANEL_LIGHT
+		btn.add_theme_color_override("font_color", ItemUiTheme.TEXT_DIM)
+	btn.add_theme_stylebox_override("normal", sb)
+	var sb_hover := sb.duplicate()
+	sb_hover.bg_color = sb.bg_color.lightened(0.12)
+	btn.add_theme_stylebox_override("hover", sb_hover)
+	var sb_pressed := sb.duplicate()
+	sb_pressed.bg_color = ItemUiTheme.ACCENT.darkened(0.1)
+	btn.add_theme_stylebox_override("pressed", sb_pressed)
+
+
+func _on_chip_pressed(category: String, btn: Button) -> void:
+	_category_filter = category
+	for cat in _chip_buttons:
+		var chip: Button = _chip_buttons[cat]
+		var active := cat == category
+		chip.button_pressed = active
+		_style_chip(chip, active)
+	_apply_filter()
 
 
 func _load_catalog() -> void:
-	_load_token += 1
-	var token := _load_token
-	$VBox/StatusLabel.text = "도감 불러오는 중…"
-	var cat_idx: int = $VBox/FilterRow/CategoryOption.selected
-	if cat_idx < 0:
-		cat_idx = 0
-	var category: String = str($VBox/FilterRow/CategoryOption.get_item_metadata(cat_idx))
-	var search: String = $VBox/FilterRow/SearchBox.text.strip_edges()
-	var payload: Dictionary = await ApiClient.fetch_item_catalog(category, "", search, 300)
-	if token != _load_token:
+	_status.text = "도감 불러오는 중..."
+	_list.clear()
+	_detail.clear()
+	var result: Dictionary = await ApiClient.fetch_item_catalog("", "", "", 500)
+	if result.is_empty():
+		_status.text = "도감 로드 실패"
+		_count_label.text = ""
 		return
-	if payload.is_empty():
-		$VBox/StatusLabel.text = "도감을 불러오지 못했습니다."
-		return
-	var counts: Dictionary = payload.get("counts", {})
-	_items = payload.get("items", [])
-	$VBox/StatusLabel.text = "총 %s종 · 표시 %s개" % [
-		counts.get("total", "?"),
-		payload.get("filtered_count", _items.size()),
-	]
-	_fill_item_list()
+	_items = result.get("items", [])
+	var counts: Dictionary = result.get("counts", {})
+	_apply_filter()
+	_status.text = "총 %s종 아이템 · 클릭하면 상세 정보" % counts.get("total", _items.size())
 
 
-func _fill_item_list() -> void:
-	var list: ItemList = $VBox/ItemList
-	list.clear()
-	for it in _items:
-		if not it is Dictionary:
+func _apply_filter() -> void:
+	var query := _search.text.strip_edges().to_lower()
+	_filtered.clear()
+	for item in _items:
+		if not item is Dictionary:
 			continue
-		var icon := str(it.get("icon", "📦"))
-		var label := str(it.get("label", it.get("item_id", "?")))
-		var grade := str(it.get("grade_label", it.get("grade", "")))
-		var cat := str(it.get("category", ""))
-		var idx := list.add_item("%s %s [%s·%s]" % [icon, label, grade, cat])
-		list.set_item_metadata(idx, it.get("item_id", ""))
+		var cat: String = str(item.get("category", ""))
+		if _category_filter != "all" and cat != _category_filter:
+			continue
+		if query != "":
+			var label: String = str(item.get("label", "")).to_lower()
+			var item_id: String = str(item.get("item_id", "")).to_lower()
+			var desc: String = str(item.get("description", "")).to_lower()
+			if query not in label and query not in item_id and query not in desc:
+				continue
+		_filtered.append(item)
+	_refresh_list()
+
+
+func _refresh_list() -> void:
+	_list.clear()
+	for item in _filtered:
+		var grade: String = str(item.get("grade", "common"))
+		var icon := str(item.get("icon", "📦"))
+		var label := str(item.get("label", item.get("item_id", "?")))
+		var grade_txt := str(item.get("grade_label", ItemUiTheme.grade_label(grade)))
+		var idx := _list.add_item("%s %s [%s]" % [icon, label, grade_txt])
+		_list.set_item_metadata(idx, item.get("item_id", ""))
+		_list.set_item_custom_fg_color(idx, ItemUiTheme.grade_color(grade))
+	_count_label.text = "%d / %d 종" % [_filtered.size(), _items.size()]
+	if _filtered.is_empty():
+		_detail.text = "[center][color=#8899bb]조건에 맞는 아이템이 없습니다.[/color][/center]"
+		return
+	if _list.get_item_count() > 0:
+		_list.select(0)
+		_on_item_selected(0)
+
+
+func _on_search_changed(_text: String) -> void:
+	_apply_filter()
 
 
 func _on_item_selected(index: int) -> void:
 	if index < 0:
 		return
-	var list: ItemList = $VBox/ItemList
-	var item_id: String = str(list.get_item_metadata(index))
-	var it: Dictionary = _find_item(item_id)
-	if it.is_empty():
-		var detail: Dictionary = await ApiClient.fetch_item_detail(item_id)
-		it = detail
-	_render_detail(it)
+	var item_id: String = str(_list.get_item_metadata(index))
+	var item: Dictionary = _find_item(item_id)
+	if item.is_empty():
+		item = await ApiClient.fetch_item_detail(item_id)
+	_detail.text = ItemUiTheme.detail_bbcode(item)
 
 
 func _find_item(item_id: String) -> Dictionary:
-	for it in _items:
+	for it in _filtered:
 		if it is Dictionary and str(it.get("item_id", "")) == item_id:
 			return it
 	return {}
-
-
-func _render_detail(it: Dictionary) -> void:
-	if it.is_empty():
-		$VBox/DetailLabel.text = "항목을 선택하세요."
-		return
-	var lines: PackedStringArray = []
-	lines.append("%s %s" % [it.get("icon", "📦"), it.get("label", "?")])
-	lines.append("ID: %s" % it.get("item_id", ""))
-	lines.append("분류: %s · 등급: %s (%s)" % [
-		it.get("category", "?"),
-		it.get("grade_label", it.get("grade", "?")),
-		it.get("rarity_color", ""),
-	])
-	if it.get("description"):
-		lines.append("")
-		lines.append(str(it.get("description")))
-	lines.append("")
-	if it.get("attack"):
-		lines.append("공격력: %s" % it.get("attack"))
-	if it.get("defense"):
-		lines.append("방어력: %s" % it.get("defense"))
-	if it.get("hp_restore"):
-		lines.append("HP 회복: %s" % it.get("hp_restore"))
-	if it.get("mp_restore"):
-		lines.append("MP 회복: %s" % it.get("mp_restore"))
-	if it.get("value_gold"):
-		lines.append("가치: %s 골드" % it.get("value_gold"))
-	if it.get("equippable"):
-		lines.append("착용 가능 슬롯: %s" % it.get("slot", "weapon"))
-	if it.get("consumable"):
-		lines.append("소비 아이템")
-	lines.append("")
-	lines.append("인벤토리에서 착용/사용하세요.")
-	$VBox/DetailLabel.text = "\n".join(lines)
 
 
 func _on_open_inventory_pressed() -> void:
@@ -149,4 +191,4 @@ func _on_back_pressed() -> void:
 
 
 func _on_api_error(message: String) -> void:
-	$VBox/StatusLabel.text += "\n[오류] %s" % message
+	_status.text += "\n[오류] %s" % message

--- a/fantasy_simulator/client/godot/scenes/item_catalog.tscn
+++ b/fantasy_simulator/client/godot/scenes/item_catalog.tscn
@@ -1,6 +1,6 @@
-[gd_scene load_steps=2 format=3 uid="uid://eldoria_item_catalog"]
+[gd_scene load_steps=2 format=3 uid="uid://item_catalog_scene"]
 
-[ext_resource type="Script" path="res://scenes/item_catalog.gd" id="1_cat"]
+[ext_resource type="Script" path="res://scenes/item_catalog.gd" id="1"]
 
 [node name="ItemCatalog" type="Control"]
 layout_mode = 3
@@ -9,64 +9,130 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-script = ExtResource("1_cat")
+script = ExtResource("1")
 
-[node name="VBox" type="VBoxContainer" parent="."]
+[node name="Root" type="ColorRect" parent="."]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 20.0
-offset_top = 16.0
-offset_right = -20.0
-offset_bottom = -16.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_constants/separation = 8
+color = Color(0.043, 0.059, 0.102, 1)
 
-[node name="Title" type="Label" parent="VBox"]
+[node name="Margin" type="MarginContainer" parent="Root"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 16
+
+[node name="VBox" type="VBoxContainer" parent="Root/Margin"]
 layout_mode = 2
-text = "아이템 도감 (API)"
+theme_override_constants/separation = 12
+
+[node name="Header" type="HBoxContainer" parent="Root/Margin/VBox"]
+layout_mode = 2
+
+[node name="BackButton" type="Button" parent="Root/Margin/VBox/Header"]
+custom_minimum_size = Vector2(88, 40)
+layout_mode = 2
+text = "← 메뉴"
+
+[node name="Title" type="Label" parent="Root/Margin/VBox/Header"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_colors/font_color = Color(0.91, 0.78, 0.42, 1)
+theme_override_font_sizes/font_size = 28
+text = "📖 아이템 도감"
 horizontal_alignment = 1
 
-[node name="StatusLabel" type="Label" parent="VBox"]
+[node name="CountLabel" type="Label" parent="Root/Margin/VBox/Header"]
+custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
-text = "—"
+theme_override_colors/font_color = Color(0.55, 0.62, 0.78, 1)
+theme_override_font_sizes/font_size = 14
+text = "0 / 0 종"
+horizontal_alignment = 2
 
-[node name="FilterRow" type="HBoxContainer" parent="VBox"]
+[node name="InventoryButton" type="Button" parent="Root/Margin/VBox/Header"]
+custom_minimum_size = Vector2(88, 40)
+layout_mode = 2
+text = "🎒 인벤"
+
+[node name="Toolbar" type="VBoxContainer" parent="Root/Margin/VBox"]
 layout_mode = 2
 theme_override_constants/separation = 8
 
-[node name="CategoryOption" type="OptionButton" parent="VBox/FilterRow"]
+[node name="SearchRow" type="HBoxContainer" parent="Root/Margin/VBox/Toolbar"]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="SearchEdit" type="LineEdit" parent="Root/Margin/VBox/Toolbar/SearchRow"]
 layout_mode = 2
 size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 15
+placeholder_text = "이름 또는 ID로 검색..."
 
-[node name="SearchBox" type="LineEdit" parent="VBox/FilterRow"]
-layout_mode = 2
-size_flags_horizontal = 3
-placeholder_text = "이름 검색…"
-
-[node name="RefreshButton" type="Button" parent="VBox/FilterRow"]
+[node name="RefreshButton" type="Button" parent="Root/Margin/VBox/Toolbar/SearchRow"]
+custom_minimum_size = Vector2(100, 40)
 layout_mode = 2
 text = "새로고침"
 
-[node name="ItemList" type="ItemList" parent="VBox"]
-custom_minimum_size = Vector2(0, 280)
+[node name="ChipRow" type="HBoxContainer" parent="Root/Margin/VBox/Toolbar"]
+layout_mode = 2
+theme_override_constants/separation = 6
+
+[node name="Body" type="HBoxContainer" parent="Root/Margin/VBox"]
 layout_mode = 2
 size_flags_vertical = 3
+theme_override_constants/separation = 14
 
-[node name="DetailLabel" type="TextEdit" parent="VBox"]
-custom_minimum_size = Vector2(0, 180)
+[node name="ListPanel" type="PanelContainer" parent="Root/Margin/VBox/Body"]
+custom_minimum_size = Vector2(340, 0)
 layout_mode = 2
-editable = false
-wrap_mode = 1
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.42
 
-[node name="OpenInventoryButton" type="Button" parent="VBox"]
+[node name="Margin" type="MarginContainer" parent="Root/Margin/VBox/Body/ListPanel"]
 layout_mode = 2
-text = "인벤토리 열기"
+theme_override_constants/margin_left = 4
+theme_override_constants/margin_top = 4
+theme_override_constants/margin_right = 4
+theme_override_constants/margin_bottom = 4
 
-[node name="BackButton" type="Button" parent="VBox"]
+[node name="List" type="ItemList" parent="Root/Margin/VBox/Body/ListPanel/Margin"]
 layout_mode = 2
-text = "메인 메뉴"
+size_flags_vertical = 3
+allow_reselect = true
 
-[connection signal="item_selected" from="VBox/ItemList" to="." method="_on_item_selected"]
+[node name="DetailPanel" type="PanelContainer" parent="Root/Margin/VBox/Body"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.58
+
+[node name="Margin" type="MarginContainer" parent="Root/Margin/VBox/Body/DetailPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 12
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_bottom = 12
+
+[node name="Detail" type="RichTextLabel" parent="Root/Margin/VBox/Body/DetailPanel/Margin"]
+custom_minimum_size = Vector2(0, 320)
+layout_mode = 2
+size_flags_vertical = 3
+bbcode_enabled = true
+fit_content = true
+scroll_active = true
+
+[node name="StatusLabel" type="Label" parent="Root/Margin/VBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.45, 0.52, 0.65, 1)
+theme_override_font_sizes/font_size = 13
+text = "준비 중..."

--- a/fantasy_simulator/client/godot/scripts/ui/item_ui_theme.gd
+++ b/fantasy_simulator/client/godot/scripts/ui/item_ui_theme.gd
@@ -1,0 +1,138 @@
+extends RefCounted
+class_name ItemUiTheme
+
+## Shared palette for catalog / inventory (dark fantasy codex style).
+
+const BG := Color(0.043, 0.059, 0.102, 1.0)
+const PANEL := Color(0.11, 0.14, 0.2, 0.95)
+const PANEL_LIGHT := Color(0.16, 0.2, 0.28, 1.0)
+const PANEL_BORDER := Color(0.45, 0.36, 0.22, 1.0)
+const ACCENT := Color(0.35, 0.55, 0.92, 1.0)
+const GOLD := Color(0.91, 0.78, 0.42, 1.0)
+const TEXT := Color(0.93, 0.9, 0.84, 1.0)
+const TEXT_DIM := Color(0.55, 0.62, 0.78, 1.0)
+const MUTED := Color(0.65, 0.6, 0.52, 1.0)
+
+const GRADE_COLORS := {
+	"common": Color(0.6, 0.63, 0.65),
+	"high": Color(0.25, 0.72, 0.38),
+	"rare": Color(0.23, 0.55, 0.96),
+	"hero": Color(0.66, 0.33, 0.97),
+	"legend": Color(0.96, 0.62, 0.12),
+	"mythic": Color(0.94, 0.27, 0.27),
+	"demigod": Color(0.99, 0.84, 0.35),
+}
+
+const GRADE_LABELS := {
+	"common": "일반",
+	"high": "고급",
+	"rare": "희귀",
+	"hero": "영웅",
+	"legend": "전설",
+	"mythic": "신화",
+	"demigod": "준신",
+}
+
+const CATEGORY_ICONS := {
+	"weapon": "⚔️",
+	"armor": "🛡️",
+	"accessory": "💍",
+	"potion": "🧪",
+	"magic": "📜",
+	"material": "🪨",
+}
+
+
+static func grade_color(grade: String) -> Color:
+	return GRADE_COLORS.get(grade, TEXT)
+
+
+static func grade_label(grade: String) -> String:
+	return GRADE_LABELS.get(grade, grade)
+
+
+static func panel_style(border: Color = PANEL_BORDER, radius: int = 8) -> StyleBoxFlat:
+	var s := StyleBoxFlat.new()
+	s.bg_color = PANEL
+	s.border_color = border
+	s.set_border_width_all(2)
+	s.set_corner_radius_all(radius)
+	s.content_margin_left = 12
+	s.content_margin_right = 12
+	s.content_margin_top = 10
+	s.content_margin_bottom = 10
+	return s
+
+
+static func list_line(item: Dictionary) -> String:
+	var icon := str(item.get("icon", CATEGORY_ICONS.get(item.get("category", ""), "📦")))
+	var label := str(item.get("label", item.get("item_id", "?")))
+	var grade := str(item.get("grade_label", grade_label(str(item.get("grade", "")))))
+	return "%s  %s   · %s" % [icon, label, grade]
+
+
+static func detail_bbcode(item: Dictionary) -> String:
+	if item.is_empty():
+		return "[center][color=#8899bb]왼쪽 목록에서 아이템을 선택하세요[/color][/center]"
+	var grade: String = str(item.get("grade", "common"))
+	var col := grade_color(grade).to_html(false)
+	var icon := str(item.get("icon", CATEGORY_ICONS.get(item.get("category", ""), "📦")))
+	var label := str(item.get("label", item.get("name", item.get("item_id", "?"))))
+	var lines: PackedStringArray = []
+	lines.append("[center][font_size=26]%s[/font_size][/center]" % icon)
+	lines.append("[center][font_size=20][color=%s]%s[/color][/font_size][/center]" % [col, label])
+	lines.append("")
+	lines.append(
+		"[color=#c9a84c]등급[/color]  [color=%s]%s[/color]   ·   [color=#c9a84c]분류[/color]  %s"
+		% [col, item.get("grade_label", grade_label(grade)), _category_ko(str(item.get("category", "")))]
+	)
+	if item.get("quantity"):
+		lines.append("[color=#c9a84c]보유[/color]  x%s" % item.get("quantity"))
+	if item.get("description"):
+		lines.append("")
+		lines.append("[color=#ddd5c8]%s[/color]" % str(item.get("description")))
+	lines.append("")
+	lines.append("[color=#c9a84c]── 스탯 ──[/color]")
+	var stats: Array[String] = []
+	if item.get("attack"):
+		stats.append("⚔ 공격 %s" % item.get("attack"))
+	if item.get("defense"):
+		stats.append("🛡 방어 %s" % item.get("defense"))
+	if item.get("hp_restore"):
+		stats.append("❤ HP +%s" % item.get("hp_restore"))
+	if item.get("mp_restore"):
+		stats.append("💧 MP +%s" % item.get("mp_restore"))
+	if item.get("scroll_damage"):
+		stats.append("✨ 마법 피해 %s" % item.get("scroll_damage"))
+	if item.get("value_gold"):
+		stats.append("🪙 %s 골드" % item.get("value_gold"))
+	if stats.is_empty():
+		lines.append("[color=#888]—[/color]")
+	else:
+		for s in stats:
+			lines.append("[color=#e8e0d4]  %s[/color]" % s)
+	if item.get("equippable"):
+		lines.append("")
+		lines.append("[color=#7ec8ff]착용 가능 · %s[/color]" % item.get("slot", "weapon"))
+	if item.get("consumable"):
+		lines.append("[color=#7ec8ff]소비 아이템[/color]")
+	lines.append("")
+	lines.append("[center][color=#666][i]%s[/i][/color][/center]" % item.get("item_id", ""))
+	return "\n".join(lines)
+
+
+static func _category_ko(cat: String) -> String:
+	match cat:
+		"weapon":
+			return "무기"
+		"armor":
+			return "방어구"
+		"accessory":
+			return "장신구"
+		"potion":
+			return "물약"
+		"magic":
+			return "마법"
+		"material":
+			return "재료"
+	return cat


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The item catalog screen failed to load because `item_catalog.gd` referenced the wrong node path for `RefreshButton`. This PR fixes that bug and refreshes the catalog/inventory UI with a darker fantasy theme.

## Changes

- **Bug fix:** Correct scene node paths so `_ready()` no longer errors on catalog open
- **`item_ui_theme.gd`:** Shared palette, grade colors/labels, BBCode detail renderer
- **Item catalog:** Dark background, category filter chips, live search, grade-colored list, rich detail panel, inventory shortcut
- **Inventory:** Equipment + consumable lists with grade colors, equipped gear panel (BBCode), character selector, starter pack button

## How to test

```bash
cd fantasy_simulator
uvicorn api.server:app --port 8765
# Godot → 새 게임 → 아이템 도감 / 인벤토리
```

- Catalog should list ~213 items with colored grades
- Filter chips and search should narrow the list
- Inventory should show owned gear and consumables after granting starter pack

## Verification

- `bash scripts/verify.sh` — 275 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d47ad9e-531c-4119-8aaf-f35fd4e3e3ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d47ad9e-531c-4119-8aaf-f35fd4e3e3ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

