### PR TITLE
ci(cpow): mobile-friendly publish workflow for cpow-world repo

### DIFF
--- a/.github/workflows/publish-cpow-world.yml
+++ b/.github/workflows/publish-cpow-world.yml
@@ -1,0 +1,30 @@
+name: Publish CPoW World
+
+# test1/cpow-world 브랜치 → weed97/cpow-world repo 로 push (모바일에서 Run workflow 가능)
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cpow-world export branch
+        uses: actions/checkout@v4
+        with:
+          ref: cpow-world
+          fetch-depth: 0
+
+      - name: Push to weed97/cpow-world
+        env:
+          PUSH_TOKEN: ${{ secrets.CPOW_WORLD_PUSH_TOKEN }}
+        run: |
+          if [ -z "$PUSH_TOKEN" ]; then
+            echo "::error::CPOW_WORLD_PUSH_TOKEN secret is not set."
+            echo "See docs/MOBILE_PUSH_CPOW.md"
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git branch -M main
+          git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/weed97/cpow-world.git"
+          git push -u origin main --force

--- a/README_CPOW.md
+++ b/README_CPOW.md
@@ -16,7 +16,7 @@ bash scripts/verify.sh
 ```
 
 `test1`에 아직 코드가 남아 있으면 → [docs/SPLIT_REPO.md](docs/SPLIT_REPO.md)  
-(최초 push 전이면 `test1`의 `cpow-world` 브랜치에서 push — 아래 참고)
+**모바일에서 push:** → [docs/MOBILE_PUSH_CPOW.md](docs/MOBILE_PUSH_CPOW.md)
 
 ## 구조
 

--- a/docs/MOBILE_PUSH_CPOW.md
+++ b/docs/MOBILE_PUSH_CPOW.md
@@ -1,0 +1,60 @@
+# 모바일에서 cpow-world로 push하기
+
+PC 터미널 없이 **GitHub 앱/브라우저**만으로 초기 push 하는 방법입니다.
+
+## 방법 A — Actions 버튼 (추천, 1회 설정)
+
+### 1) 토큰 만들기 (브라우저, 2분)
+
+1. https://github.com/settings/tokens → **Generate new token (classic)**
+2. Note: `cpow-world-push`
+3. Scope: **`repo`** 체크
+4. 생성 후 토큰 문자열 **복사** (한 번만 보임)
+
+### 2) test1에 시크릿 등록
+
+1. https://github.com/weed97/test1/settings/secrets/actions
+2. **New repository secret**
+3. Name: `CPOW_WORLD_PUSH_TOKEN`
+4. Value: 위에서 복사한 토큰 → Save
+
+### 3) 워크플로 실행 (모바일 OK)
+
+1. https://github.com/weed97/test1/actions/workflows/publish-cpow-world.yml
+2. **Run workflow** → Run workflow
+3. 완료 후 https://github.com/weed97/cpow-world 에 코드 확인
+
+---
+
+## 방법 B — GitHub.dev 터미널 (토큰 없이, 로그인만)
+
+1. 모바일 Chrome/Safari에서 열기:  
+   **https://github.dev/weed97/test1/tree/cpow-world**
+2. 하단 **Terminal** 탭 (또는 메뉴 → Terminal)
+3. 아래 입력:
+
+```bash
+git branch -M main
+git remote set-url origin https://github.com/weed97/cpow-world.git
+git push -u origin main
+```
+
+4. GitHub 로그인 창이 뜨면 승인
+
+---
+
+## 방법 C — 나중에 PC에서
+
+```bash
+git clone -b cpow-world https://github.com/weed97/test1.git cpow-world
+cd cpow-world
+git branch -M main
+git remote set-url origin https://github.com/weed97/cpow-world.git
+git push -u origin main
+```
+
+---
+
+## 확인
+
+push 성공 후 repo에 `cpow_engine/`, `README.md` 등이 보이면 완료입니다.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
모바일에서 `git push` 없이 cpow-world repo에 코드를 올리기 위한 Actions 워크플로입니다.

**사용법:** `docs/MOBILE_PUSH_CPOW.md` 참고
1. PAT 생성 → `CPOW_WORLD_PUSH_TOKEN` 시크릿 등록 (1회)
2. Actions → Publish CPoW World → Run workflow
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f2b450d-0aad-4b1b-8498-a8fcb841156a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f2b450d-0aad-4b1b-8498-a8fcb841156a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

