### PR TITLE
fix(cpow): validate PAT and document 403 fix for mobile publish

### DIFF
--- a/.github/workflows/publish-cpow-world.yml
+++ b/.github/workflows/publish-cpow-world.yml
@@ -14,17 +14,39 @@ jobs:
           ref: cpow-world
           fetch-depth: 0
 
-      - name: Push to weed97/cpow-world
+      - name: Validate push token
         env:
           PUSH_TOKEN: ${{ secrets.CPOW_WORLD_PUSH_TOKEN }}
         run: |
           if [ -z "$PUSH_TOKEN" ]; then
-            echo "::error::CPOW_WORLD_PUSH_TOKEN secret is not set."
+            echo "::error::CPOW_WORLD_PUSH_TOKEN secret is not set on weed97/test1."
             echo "See docs/MOBILE_PUSH_CPOW.md"
             exit 1
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          CODE=$(curl -s -o /tmp/repo_check.json -w "%{http_code}" \
+            -H "Authorization: Bearer ${PUSH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/weed97/cpow-world")
+          if [ "$CODE" != "200" ]; then
+            echo "::error::Token cannot access weed97/cpow-world (HTTP ${CODE})."
+            echo "Use a **weed97** account classic PAT with repo scope,"
+            echo "or fine-grained PAT with cpow-world Contents read/write."
+            cat /tmp/repo_check.json || true
+            exit 1
+          fi
+          if ! git ls-remote "https://x-access-token:${PUSH_TOKEN}@github.com/weed97/cpow-world.git" HEAD >/dev/null 2>&1; then
+            echo "::error::Token can read API but cannot push to cpow-world."
+            echo "Classic: check full repo scope. Fine-grained: Contents write on cpow-world."
+            exit 1
+          fi
+          echo "Token OK — can access cpow-world."
+
+      - name: Push to weed97/cpow-world
+        env:
+          PUSH_TOKEN: ${{ secrets.CPOW_WORLD_PUSH_TOKEN }}
+        run: |
+          git config user.name "weed97"
+          git config user.email "weed97@users.noreply.github.com"
           git branch -M main
           git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/weed97/cpow-world.git"
           git push -u origin main --force

--- a/docs/MOBILE_PUSH_CPOW.md
+++ b/docs/MOBILE_PUSH_CPOW.md
@@ -2,36 +2,66 @@
 
 PC 터미널 없이 **GitHub 앱/브라우저**만으로 초기 push 하는 방법입니다.
 
-## 방법 A — Actions 버튼 (추천, 1회 설정)
+---
 
-### 1) 토큰 만들기 (브라우저, 2분)
+## ⚠️ 403 `Permission denied to github-actions[bot]` 나올 때
 
-1. https://github.com/settings/tokens → **Generate new token (classic)**
-2. Note: `cpow-world-push`
-3. Scope: **`repo`** 체크
-4. 생성 후 토큰 문자열 **복사** (한 번만 보임)
+Actions 로그에 이렇게 보이면 **토큰 권한 문제**입니다:
 
-### 2) test1에 시크릿 등록
+```text
+Permission to weed97/cpow-world.git denied
+```
 
-1. https://github.com/weed97/test1/settings/secrets/actions
-2. **New repository secret**
-3. Name: `CPOW_WORLD_PUSH_TOKEN`
-4. Value: 위에서 복사한 토큰 → Save
+### 해결 (weed97 계정으로 로그인한 브라우저에서)
 
-### 3) 워크플로 실행 (모바일 OK)
+1. **기존 시크릿 삭제**  
+   https://github.com/weed97/test1/settings/secrets/actions  
+   → `CPOW_WORLD_PUSH_TOKEN` 있으면 **Remove**
 
-1. https://github.com/weed97/test1/actions/workflows/publish-cpow-world.yml
-2. **Run workflow** → Run workflow
-3. 완료 후 https://github.com/weed97/cpow-world 에 코드 확인
+2. **새 토큰 — Classic 권장**  
+   https://github.com/settings/tokens → **Generate new token (classic)**  
+   - Note: `cpow-world-push`  
+   - Expiration: 90 days (원하는 기간)  
+   - ✅ **`repo`** 전체 체크 (private repo면 필수)  
+   - Generate → `ghp_...` 로 시작하는 문자열 **전부 복사**
+
+   > Fine-grained 쓸 경우:  
+   > https://github.com/settings/tokens?type=beta  
+   > - Repository access: **Only select** → **`cpow-world`만** 선택  
+   > - Permissions → **Contents: Read and write**  
+   > - Metadata는 Read (기본)
+
+3. **시크릿 다시 등록**  
+   https://github.com/weed97/test1/settings/secrets/actions  
+   - Name: `CPOW_WORLD_PUSH_TOKEN` (철자 정확히)  
+   - Secret: 붙여넣기 (앞뒤 공백 없이)
+
+4. **워크플로 재실행**  
+   https://github.com/weed97/test1/actions/workflows/publish-cpow-world.yml  
+   → **Run workflow**
 
 ---
 
-## 방법 B — GitHub.dev 터미널 (토큰 없이, 로그인만)
+## 방법 A — Actions 버튼 (추천)
 
-1. 모바일 Chrome/Safari에서 열기:  
-   **https://github.dev/weed97/test1/tree/cpow-world**
-2. 하단 **Terminal** 탭 (또는 메뉴 → Terminal)
-3. 아래 입력:
+위 403 해결 후:
+
+1. https://github.com/weed97/test1/actions/workflows/publish-cpow-world.yml  
+2. **Run workflow** → Run workflow  
+3. https://github.com/weed97/cpow-world 에 `cpow_engine/` 등 확인
+
+---
+
+## 방법 B — GitHub.dev (토큰 없이, 더 쉬울 수 있음)
+
+**weed97**으로 로그인한 모바일 브라우저에서:
+
+1. 열기: **https://github.dev/weed97/test1/tree/cpow-world**  
+   (일반 github.com 말고 **github.dev** 주소)
+
+2. 메뉴(≡) → **Terminal** (터미널)
+
+3. 한 줄씩 입력:
 
 ```bash
 git branch -M main
@@ -39,11 +69,12 @@ git remote set-url origin https://github.com/weed97/cpow-world.git
 git push -u origin main
 ```
 
-4. GitHub 로그인 창이 뜨면 승인
+4. GitHub 로그인/권한 창 → **Authorize**  
+   (본인 계정이면 토큰 없이 push 됨)
 
 ---
 
-## 방법 C — 나중에 PC에서
+## 방법 C — PC에서 나중에
 
 ```bash
 git clone -b cpow-world https://github.com/weed97/test1.git cpow-world
@@ -57,4 +88,5 @@ git push -u origin main
 
 ## 확인
 
-push 성공 후 repo에 `cpow_engine/`, `README.md` 등이 보이면 완료입니다.
+push 성공 후 https://github.com/weed97/cpow-world 에  
+`cpow_engine/`, `cpow_api/`, `README.md` 가 보이면 완료입니다.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
403 Permission denied 해결용:

- push 전 토큰 API/ls-remote 검증
- MOBILE_PUSH_CPOW.md에 403 원인·classic PAT 재등록 절차 추가
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f2b450d-0aad-4b1b-8498-a8fcb841156a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f2b450d-0aad-4b1b-8498-a8fcb841156a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

