### PR TITLE
Add open-world biome, mining, and modular building scaffold

### DIFF
--- a/cpow_api/areas.py
+++ b/cpow_api/areas.py
@@ -80,9 +80,23 @@ def handle_area_create(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def handle_area_adventure(payload: dict[str, Any]) -> dict[str, Any]:
-    area = _registry.get_or_raise(str(payload["area_id"]))
+    area_id = str(payload["area_id"])
     actor_id = str(payload.get("actor_id", "anonymous"))
     action_type = str(payload.get("action", "explore"))
+
+    if action_type == "mine":
+        from cpow_api.world import handle_world_mine
+
+        mine_out = handle_world_mine({**payload, "area_id": area_id, "actor_id": actor_id})
+        return {
+            "ok": mine_out.get("ok", False),
+            "area_id": area_id,
+            "action": "mine",
+            "reason": mine_out.get("reason", ""),
+            **mine_out,
+        }
+
+    area = _registry.get_or_raise(area_id)
     result = area.submit_adventure(
         actor_id,
         action_type,

--- a/cpow_api/server.py
+++ b/cpow_api/server.py
@@ -57,6 +57,13 @@ from cpow_api.collab import (
     handle_collab_pulse,
     handle_collab_state,
 )
+from cpow_api.world import (
+    handle_world_boss_loot,
+    handle_world_build_validate,
+    handle_world_catalog,
+    handle_world_cell,
+    handle_world_mine,
+)
 from cpow_api.route_helpers import authed_call, authed_call_400, authed_call_404
 from cpow_api.xr import _store as _xr_store
 from cpow_api.xr import handle_xr_connect, handle_xr_creation, handle_xr_world
@@ -217,6 +224,45 @@ class AreaAdventureRequest(BaseModel):
     action: str = "explore"
     target_object_id: Optional[str] = None
     label: Optional[str] = None
+    x: Optional[float] = None
+    z: Optional[float] = None
+    depth_y: Optional[int] = None
+    tool_type: Optional[str] = None
+    tool_tier: Optional[int] = None
+    ore_id: Optional[str] = None
+    consumable: Optional[str] = None
+    cell_size: Optional[int] = None
+
+
+class WorldCellRequest(BaseModel):
+    area_id: str
+    x: float = 0.0
+    z: float = 0.0
+    depth_y: int = 48
+    cell_size: int = 64
+    advance_tick: bool = False
+
+
+class WorldMineRequest(BaseModel):
+    area_id: str
+    actor_id: str = "anonymous"
+    x: float = 0.0
+    z: float = 0.0
+    depth_y: int = 48
+    cell_size: int = 64
+    tool_type: str = "pickaxe"
+    tool_tier: int = 1
+    ore_id: Optional[str] = None
+    consumable: Optional[str] = None
+
+
+class WorldBuildValidateRequest(BaseModel):
+    area_id: str = ""
+    biome_id: str = "plains"
+    blueprint_id: str
+    placed_modules: dict[str, int] = Field(default_factory=dict)
+    placed_materials: dict[str, int] = Field(default_factory=dict)
+    civilization_level: int = 0
 
 
 class AreaMutateRequest(BaseModel):
@@ -552,6 +598,41 @@ def identity_register(
 @app.get("/v1/identity/status")
 def identity_status(user_id: str) -> dict[str, Any]:
     return handle_identity_status(user_id)
+
+
+@app.get("/v1/world/catalog")
+def world_catalog() -> dict[str, Any]:
+    return handle_world_catalog()
+
+
+@app.post("/v1/world/cell")
+def world_cell(body: WorldCellRequest) -> dict[str, Any]:
+    return handle_world_cell(body.model_dump())
+
+
+@app.post("/v1/world/mine")
+def world_mine(
+    body: WorldMineRequest,
+    auth_user: str | None = Depends(optional_user),
+) -> dict[str, Any]:
+    return authed_call(
+        handle_world_mine, body, auth_user, "actor_id", exclude_none=True,
+    )
+
+
+@app.post("/v1/world/build/validate")
+def world_build_validate(body: WorldBuildValidateRequest) -> dict[str, Any]:
+    return handle_world_build_validate(body.model_dump())
+
+
+@app.post("/v1/world/boss_loot")
+def world_boss_loot(
+    body: dict[str, Any],
+    auth_user: str | None = Depends(optional_user),
+) -> dict[str, Any]:
+    return authed_call(
+        handle_world_boss_loot, body, auth_user, "actor_id", exclude_none=True,
+    )
 
 
 @app.get("/v1/areas/list")

--- a/cpow_api/world.py
+++ b/cpow_api/world.py
@@ -1,0 +1,43 @@
+"""오픈월드 API — 바이옴·채굴·건축."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cpow_engine.world.service import get_world_service
+
+
+def handle_world_catalog() -> dict[str, Any]:
+    return get_world_service().catalog()
+
+
+def handle_world_cell(payload: dict[str, Any]) -> dict[str, Any]:
+    area_id = str(payload.get("area_id", ""))
+    if not area_id:
+        return {"ok": False, "reason": "missing_area_id"}
+    return get_world_service().inspect_cell(
+        area_id,
+        x=float(payload.get("x", 0.0)),
+        z=float(payload.get("z", 0.0)),
+        depth_y=int(payload.get("depth_y", 48)),
+        cell_size=int(payload.get("cell_size", 64)),
+        advance_tick=bool(payload.get("advance_tick", False)),
+    )
+
+
+def handle_world_mine(payload: dict[str, Any]) -> dict[str, Any]:
+    area_id = str(payload.get("area_id", ""))
+    if not area_id:
+        return {"ok": False, "reason": "missing_area_id"}
+    return get_world_service().mine(area_id, payload)
+
+
+def handle_world_build_validate(payload: dict[str, Any]) -> dict[str, Any]:
+    return get_world_service().validate_build(payload)
+
+
+def handle_world_boss_loot(payload: dict[str, Any]) -> dict[str, Any]:
+    area_id = str(payload.get("area_id", ""))
+    if not area_id:
+        return {"ok": False, "reason": "missing_area_id"}
+    return get_world_service().boss_loot(area_id, payload)

--- a/cpow_engine/areas/law_validator.py
+++ b/cpow_engine/areas/law_validator.py
@@ -29,6 +29,17 @@ ALLOWED_PROPERTY_NAMES: frozenset[str] = frozenset({
     "crop_plot",
     "is_npc_creation",
     "npc_owner",
+    "purpose",
+    "biome",
+    "source",
+    "stack_amount",
+    "material_tier",
+    "tool_type",
+    "mining_tier",
+    "module_id",
+    "blueprint_id",
+    "building_type",
+    "construction_stage",
 })
 
 PROPERTY_BOUNDS: dict[str, tuple[float, float]] = {

--- a/cpow_engine/tests/test_world.py
+++ b/cpow_engine/tests/test_world.py
@@ -1,0 +1,169 @@
+"""월드 — 바이옴·채굴·모듈 건축."""
+
+from __future__ import annotations
+
+import unittest
+
+from cpow_engine.world.biomes import BiomeId, ZoneClass
+from cpow_engine.world.building import validate_blueprint_placement
+from cpow_engine.world.grid import biome_at, cell_from_world, ore_at_position
+from cpow_engine.world.mining import MiningProfile, attempt_mine
+from cpow_engine.world.ores import ORE_CATALOG
+from cpow_engine.world.service import WorldService
+from cpow_engine.world.tools import resolve_tool
+
+
+class TestWorldGrid(unittest.TestCase):
+    def test_biome_deterministic(self) -> None:
+        a = biome_at("seed1", 0, 0).biome_id
+        b = biome_at("seed1", 0, 0).biome_id
+        c = biome_at("seed1", 1, 0).biome_id
+        self.assertEqual(a, b)
+        self.assertIsInstance(a, BiomeId)
+
+    def test_cell_from_world(self) -> None:
+        self.assertEqual(cell_from_world(128.0, -32.0, 64), (2, -1))
+
+
+class TestMining(unittest.TestCase):
+    def test_pickaxe_cannot_mine_diamond_well(self) -> None:
+        ore = ORE_CATALOG["diamond_ore"]
+        tool = resolve_tool("pickaxe", 3)
+        assert tool is not None
+        profile = MiningProfile(user_id="miner")
+        result = attempt_mine(
+            actor_id="miner",
+            ore=ore,
+            tool=tool,
+            profile=profile,
+        )
+        self.assertFalse(result.ok)
+        self.assertEqual(result.reason, "requires_drill")
+
+    def test_drill_mines_diamond(self) -> None:
+        ore = ORE_CATALOG["diamond_ore"]
+        tool = resolve_tool("drill", 4)
+        assert tool is not None
+        profile = MiningProfile(user_id="miner")
+        result = attempt_mine(
+            actor_id="miner",
+            ore=ore,
+            tool=tool,
+            profile=profile,
+        )
+        self.assertTrue(result.ok, result.reason)
+        self.assertGreater(result.amount, 0.0)
+
+    def test_black_mithril_shard_boss_only(self) -> None:
+        ore = ORE_CATALOG["black_mithril_shard"]
+        tool = resolve_tool("drill", 6)
+        assert tool is not None
+        result = attempt_mine(
+            actor_id="x",
+            ore=ore,
+            tool=tool,
+            profile=MiningProfile(user_id="x"),
+        )
+        self.assertFalse(result.ok)
+        self.assertEqual(result.reason, "boss_drop_only")
+
+    def test_black_mithril_ore_needs_stabilizer(self) -> None:
+        ore = ORE_CATALOG["black_mithril_ore"]
+        tool = resolve_tool("drill", 6)
+        assert tool is not None
+        result = attempt_mine(
+            actor_id="x",
+            ore=ore,
+            tool=tool,
+            profile=MiningProfile(user_id="x"),
+        )
+        self.assertFalse(result.ok)
+        self.assertEqual(result.reason, "missing_consumable")
+
+    def test_mining_tier_grows(self) -> None:
+        profile = MiningProfile(user_id="m")
+        tool = resolve_tool("pickaxe", 1)
+        assert tool is not None
+        for _ in range(30):
+            attempt_mine(
+                actor_id="m",
+                ore=ORE_CATALOG["coal"],
+                tool=tool,
+                profile=profile,
+            )
+        self.assertGreater(profile.tier, 1)
+
+
+class TestBuilding(unittest.TestCase):
+    def test_settlement_blocked_in_volcano(self) -> None:
+        result = validate_blueprint_placement(
+            biome_id="volcano",
+            blueprint_id="smelter_lv1",
+            placed_modules={
+                "foundation_2x2": 1,
+                "wall_t1": 8,
+                "furnace_box": 1,
+                "chimney_stack": 1,
+            },
+            placed_materials={"iron_plate": 12, "stone_brick": 16},
+            civilization_level=2,
+        )
+        self.assertFalse(result.ok)
+        self.assertEqual(result.reason, "settlement_only_in_safe_zone")
+
+    def test_outpost_allowed_in_desert(self) -> None:
+        result = validate_blueprint_placement(
+            biome_id="desert",
+            blueprint_id="camp_kit",
+            placed_modules={
+                "foundation_1x1": 1,
+                "wall_t1": 4,
+                "heater_core": 1,
+            },
+            placed_materials={"wood_plank": 8, "stone_brick": 4},
+        )
+        self.assertTrue(result.ok, result.reason)
+
+
+class TestWorldService(unittest.TestCase):
+    def test_cell_has_hazard_audio(self) -> None:
+        svc = WorldService()
+        out = svc.inspect_cell("area_test", x=100.0, z=50.0, advance_tick=True)
+        self.assertTrue(out.get("ok"))
+        self.assertIn("hazard", out)
+        self.assertIn("audio_cue", out["hazard"]["phase"])
+
+    def test_boss_loot_black_mithril_shard(self) -> None:
+        svc = WorldService()
+        out = svc.boss_loot("area_boss", {"actor_id": "hero", "amount": 1.0})
+        self.assertTrue(out.get("ok"))
+        self.assertEqual(
+            out["resource"]["properties"][0]["unit"],
+            "black_mithril_shard",
+        )
+
+    def test_mine_at_position(self) -> None:
+        svc = WorldService()
+        runtime = svc.runtime_for("mine_area")
+        biome = biome_at(runtime.world_seed, 0, 0)
+        ore = ore_at_position(runtime.world_seed, biome.biome_id, 40, 0, 0)
+        if ore is None:
+            ore = ORE_CATALOG["coal"]
+        out = svc.mine(
+            "mine_area",
+            {
+                "actor_id": "digger",
+                "x": 10.0,
+                "z": 10.0,
+                "depth_y": 40,
+                "tool_type": "pickaxe",
+                "tool_tier": 2,
+                "ore_id": ore.ore_id,
+            },
+        )
+        self.assertTrue(out.get("ok"), out)
+        self.assertIn("hazard_audio", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cpow_engine/world/__init__.py
+++ b/cpow_engine/world/__init__.py
@@ -1,0 +1,26 @@
+"""오픈월드 — 바이옴·채굴·모듈 건축·위험 예고."""
+
+from cpow_engine.world.biomes import BiomeId, ZoneClass, biome_catalog_public
+from cpow_engine.world.building import blueprint_catalog_public, validate_blueprint_placement
+from cpow_engine.world.grid import cell_from_world, cell_snapshot
+from cpow_engine.world.mining import MiningProfile, attempt_mine, build_resource_object
+from cpow_engine.world.ores import ore_catalog_public
+from cpow_engine.world.service import WorldService, get_world_service
+from cpow_engine.world.tools import tool_catalog_public
+
+__all__ = [
+    "BiomeId",
+    "ZoneClass",
+    "MiningProfile",
+    "WorldService",
+    "attempt_mine",
+    "biome_catalog_public",
+    "blueprint_catalog_public",
+    "build_resource_object",
+    "cell_from_world",
+    "cell_snapshot",
+    "get_world_service",
+    "ore_catalog_public",
+    "tool_catalog_public",
+    "validate_blueprint_placement",
+]

--- a/cpow_engine/world/biomes.py
+++ b/cpow_engine/world/biomes.py
@@ -1,0 +1,187 @@
+"""바이옴 정의 — 지역 규칙·위험·소리 예고."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class ZoneClass(str, Enum):
+    """건축·정착 허용 구역."""
+
+    SAFE = "safe"
+    BUFFER = "buffer"
+    DANGER = "danger"
+
+
+class BiomeId(str, Enum):
+    PLAINS = "plains"
+    FOREST = "forest"
+    HILLS = "hills"
+    COAST = "coast"
+    ALPINE = "alpine"
+    DESERT = "desert"
+    VOLCANO = "volcano"
+    OCEAN = "ocean"
+    MINE = "mine"
+    RIFT = "rift"
+
+
+@dataclass(frozen=True)
+class HazardPhase:
+    """바이옴별 주기 상태."""
+
+    phase_id: str
+    label: str
+    danger_level: int
+    audio_cue: str
+    audio_stage: str
+    seconds_to_event: float = 0.0
+
+
+@dataclass(frozen=True)
+class BiomeDef:
+    biome_id: BiomeId
+    label: str
+    zone: ZoneClass
+    phases: tuple[str, ...]
+    hazard_audio: dict[str, str] = field(default_factory=dict)
+    allows_settlement: bool = False
+    allows_outpost: bool = False
+
+    def to_dict(self) -> dict:
+        return {
+            "biome_id": self.biome_id.value,
+            "label": self.label,
+            "zone": self.zone.value,
+            "phases": list(self.phases),
+            "hazard_audio": dict(self.hazard_audio),
+            "allows_settlement": self.allows_settlement,
+            "allows_outpost": self.allows_outpost,
+        }
+
+
+BIOME_CATALOG: dict[BiomeId, BiomeDef] = {
+    BiomeId.PLAINS: BiomeDef(
+        BiomeId.PLAINS,
+        "평원",
+        ZoneClass.SAFE,
+        ("calm", "harvest", "flood_warning"),
+        {
+            "flood_warning": "env.plains.flood_rumble",
+            "flood": "env.plains.flood_surge",
+        },
+        allows_settlement=True,
+        allows_outpost=True,
+    ),
+    BiomeId.FOREST: BiomeDef(
+        BiomeId.FOREST,
+        "숲",
+        ZoneClass.SAFE,
+        ("calm", "rain", "growth"),
+        {
+            "rain": "env.forest.rain_loop",
+            "growth": "env.forest.creak",
+        },
+        allows_settlement=True,
+        allows_outpost=True,
+    ),
+    BiomeId.HILLS: BiomeDef(
+        BiomeId.HILLS,
+        "산악",
+        ZoneClass.BUFFER,
+        ("calm", "fog", "rockfall_warning"),
+        {
+            "rockfall_warning": "env.hills.stress_crack",
+            "rockfall": "env.hills.avalanche",
+        },
+        allows_outpost=True,
+    ),
+    BiomeId.COAST: BiomeDef(
+        BiomeId.COAST,
+        "해안",
+        ZoneClass.BUFFER,
+        ("calm", "tide_low", "tide_high", "tsunami_warning"),
+        {
+            "tide_low": "env.coast.tide_out",
+            "tide_high": "env.coast.tide_in",
+            "tsunami_warning": "env.coast.tsunami_rumble",
+            "tsunami": "env.coast.tsunami_roar",
+        },
+        allows_outpost=True,
+    ),
+    BiomeId.ALPINE: BiomeDef(
+        BiomeId.ALPINE,
+        "설산",
+        ZoneClass.DANGER,
+        ("calm", "blizzard_warning", "blizzard"),
+        {
+            "blizzard_warning": "env.alpine.wind_howl",
+            "blizzard": "env.alpine.blizzard_peak",
+        },
+        allows_outpost=True,
+    ),
+    BiomeId.DESERT: BiomeDef(
+        BiomeId.DESERT,
+        "사막",
+        ZoneClass.DANGER,
+        ("calm", "heat_day", "sandstorm_warning", "sandstorm"),
+        {
+            "heat_day": "env.desert.heat_shimmer",
+            "sandstorm_warning": "env.desert.wind_whistle",
+            "sandstorm": "env.desert.sand_blast",
+        },
+        allows_outpost=True,
+    ),
+    BiomeId.VOLCANO: BiomeDef(
+        BiomeId.VOLCANO,
+        "화산",
+        ZoneClass.DANGER,
+        ("calm", "tremor", "gas_warning", "eruption_warning", "eruption"),
+        {
+            "tremor": "env.volcano.low_rumble",
+            "gas_warning": "env.volcano.hiss",
+            "eruption_warning": "env.volcano.deep_boom",
+            "eruption": "env.volcano.blast",
+        },
+        allows_outpost=True,
+    ),
+    BiomeId.OCEAN: BiomeDef(
+        BiomeId.OCEAN,
+        "심해",
+        ZoneClass.DANGER,
+        ("calm", "current_shift", "pressure_warning"),
+        {
+            "current_shift": "env.ocean.drift",
+            "pressure_warning": "env.ocean.depth_pulse",
+        },
+        allows_outpost=True,
+    ),
+    BiomeId.MINE: BiomeDef(
+        BiomeId.MINE,
+        "탄광",
+        ZoneClass.BUFFER,
+        ("calm", "cave_in_warning", "cave_in"),
+        {
+            "cave_in_warning": "env.mine.timber_stress",
+            "cave_in": "env.mine.collapse",
+        },
+        allows_outpost=True,
+    ),
+    BiomeId.RIFT: BiomeDef(
+        BiomeId.RIFT,
+        "균열",
+        ZoneClass.DANGER,
+        ("calm", "rift_hum", "rift_open", "rift_close"),
+        {
+            "rift_hum": "env.rift.low_tone",
+            "rift_open": "env.rift.tear",
+            "rift_close": "env.rift.seal",
+        },
+        allows_outpost=True,
+    ),
+}
+
+
+def biome_catalog_public() -> list[dict]:
+    return [b.to_dict() for b in BIOME_CATALOG.values()]

--- a/cpow_engine/world/building.py
+++ b/cpow_engine/world/building.py
@@ -1,0 +1,155 @@
+"""모듈형 건축 — 블루프린트·구역 규칙."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from cpow_engine.world.biomes import BIOME_CATALOG, BiomeId, ZoneClass
+
+
+@dataclass(frozen=True)
+class ModuleReq:
+    module_id: str
+    count: int
+
+    def to_dict(self) -> dict:
+        return {"module_id": self.module_id, "count": int(self.count)}
+
+
+@dataclass(frozen=True)
+class BlueprintDef:
+    blueprint_id: str
+    label: str
+    building_type: str
+    zone_min: ZoneClass
+    modules: tuple[ModuleReq, ...]
+    materials: tuple[ModuleReq, ...] = ()
+    civ_min: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "blueprint_id": self.blueprint_id,
+            "label": self.label,
+            "building_type": self.building_type,
+            "zone_min": self.zone_min.value,
+            "modules": [m.to_dict() for m in self.modules],
+            "materials": [m.to_dict() for m in self.materials],
+            "civ_min": self.civ_min,
+        }
+
+
+BLUEPRINT_CATALOG: dict[str, BlueprintDef] = {
+    "camp_kit": BlueprintDef(
+        "camp_kit",
+        "원정 캠프 키트",
+        "outpost",
+        ZoneClass.DANGER,
+        (
+            ModuleReq("foundation_1x1", 1),
+            ModuleReq("wall_t1", 4),
+            ModuleReq("heater_core", 1),
+        ),
+        (ModuleReq("wood_plank", 8), ModuleReq("stone_brick", 4)),
+    ),
+    "smelter_lv1": BlueprintDef(
+        "smelter_lv1",
+        "제련소 Lv1",
+        "smelter",
+        ZoneClass.SAFE,
+        (
+            ModuleReq("foundation_2x2", 1),
+            ModuleReq("wall_t1", 8),
+            ModuleReq("furnace_box", 1),
+            ModuleReq("chimney_stack", 1),
+        ),
+        (ModuleReq("iron_plate", 12), ModuleReq("stone_brick", 16)),
+        civ_min=1,
+    ),
+    "power_line": BlueprintDef(
+        "power_line",
+        "지열 전력선",
+        "energy",
+        ZoneClass.BUFFER,
+        (
+            ModuleReq("pipe_straight", 4),
+            ModuleReq("cable_segment", 2),
+        ),
+        (ModuleReq("copper_wire", 6),),
+        civ_min=2,
+    ),
+}
+
+
+@dataclass
+class BuildValidationResult:
+    ok: bool
+    reason: str = ""
+    blueprint: dict | None = None
+    missing: list[dict] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "ok": self.ok,
+            "reason": self.reason,
+            "blueprint": self.blueprint,
+            "missing": list(self.missing),
+        }
+
+
+_ZONE_ORDER = {ZoneClass.SAFE: 0, ZoneClass.BUFFER: 1, ZoneClass.DANGER: 2}
+
+
+def _zone_allows_building(zone: ZoneClass, building_type: str) -> tuple[bool, str]:
+    if building_type in ("settlement", "smelter", "greenhouse", "town_hall"):
+        if zone != ZoneClass.SAFE:
+            return False, "settlement_only_in_safe_zone"
+        return True, "ok"
+    if building_type in ("outpost", "camp", "drill_platform", "energy"):
+        return True, "ok"
+    if zone == ZoneClass.DANGER and building_type == "fortress_core":
+        return False, "no_core_in_danger_zone"
+    return True, "ok"
+
+
+def validate_blueprint_placement(
+    *,
+    biome_id: str,
+    blueprint_id: str,
+    placed_modules: dict[str, int],
+    placed_materials: dict[str, int] | None = None,
+    civilization_level: int = 0,
+) -> BuildValidationResult:
+    bp = BLUEPRINT_CATALOG.get(blueprint_id)
+    if bp is None:
+        return BuildValidationResult(False, reason="unknown_blueprint")
+    try:
+        bid = BiomeId(biome_id)
+    except ValueError:
+        return BuildValidationResult(False, reason="unknown_biome")
+    biome = BIOME_CATALOG[bid]
+    zone_ok, zone_reason = _zone_allows_building(biome.zone, bp.building_type)
+    if not zone_ok:
+        return BuildValidationResult(False, reason=zone_reason, blueprint=bp.to_dict())
+    if _ZONE_ORDER[biome.zone] < _ZONE_ORDER[bp.zone_min]:
+        return BuildValidationResult(False, reason="zone_too_dangerous", blueprint=bp.to_dict())
+    if civilization_level < bp.civ_min:
+        return BuildValidationResult(False, reason="civilization_too_low", blueprint=bp.to_dict())
+    mats = placed_materials or {}
+    missing: list[dict] = []
+    for req in bp.modules:
+        have = int(placed_modules.get(req.module_id, 0))
+        if have < req.count:
+            missing.append({"kind": "module", **req.to_dict(), "have": have})
+    for req in bp.materials:
+        have = int(mats.get(req.module_id, 0))
+        if have < req.count:
+            missing.append({"kind": "material", **req.to_dict(), "have": have})
+    if missing:
+        return BuildValidationResult(
+            False, reason="missing_parts", blueprint=bp.to_dict(), missing=missing,
+        )
+    return BuildValidationResult(True, reason="blueprint_valid", blueprint=bp.to_dict())
+
+
+def blueprint_catalog_public() -> list[dict]:
+    return [b.to_dict() for b in BLUEPRINT_CATALOG.values()]

--- a/cpow_engine/world/grid.py
+++ b/cpow_engine/world/grid.py
@@ -1,0 +1,79 @@
+"""월드 그리드 — 좌표→바이옴·광맥."""
+
+from __future__ import annotations
+
+import hashlib
+
+from cpow_engine.world.biomes import BIOME_CATALOG, BiomeDef, BiomeId
+from cpow_engine.world.ores import ORE_CATALOG, OreDef
+
+
+_BIOME_RING: tuple[BiomeId, ...] = (
+    BiomeId.PLAINS,
+    BiomeId.FOREST,
+    BiomeId.HILLS,
+    BiomeId.COAST,
+    BiomeId.DESERT,
+    BiomeId.ALPINE,
+    BiomeId.VOLCANO,
+    BiomeId.OCEAN,
+    BiomeId.MINE,
+    BiomeId.RIFT,
+)
+
+
+def _hash_u32(seed: str, *parts: int) -> int:
+    raw = f"{seed}:{':'.join(str(p) for p in parts)}".encode()
+    return int(hashlib.sha256(raw).hexdigest()[:8], 16)
+
+
+def biome_at(seed: str, cell_x: int, cell_z: int) -> BiomeDef:
+    """결정론적 바이옴 — 에리어 시드 + 셀 좌표."""
+    h = _hash_u32(seed, cell_x, cell_z, 1)
+    idx = h % len(_BIOME_RING)
+    # 평원·숲 비중을 높임 (안전 허브 공간)
+    if h % 5 < 2:
+        idx = 0 if h % 2 == 0 else 1
+    biome_id = _BIOME_RING[idx]
+    return BIOME_CATALOG[biome_id]
+
+
+def cell_from_world(x: float, z: float, cell_size: int = 64) -> tuple[int, int]:
+    return int(x // cell_size), int(z // cell_size)
+
+
+def ore_at_position(
+    seed: str,
+    biome: BiomeId,
+    depth_y: int,
+    cell_x: int,
+    cell_z: int,
+) -> OreDef | None:
+    """위치에 노출된 광맥 (없을 수 있음)."""
+    candidates = [
+        o for o in ORE_CATALOG.values()
+        if biome in o.biomes
+        and o.min_depth <= depth_y <= o.max_depth
+        and o.source.value == "vein"
+    ]
+    if not candidates:
+        return None
+    h = _hash_u32(seed, cell_x, cell_z, depth_y, 7)
+    pick = candidates[h % len(candidates)]
+    # 희귀도 — 티어 높을수록 낮은 확률
+    rarity_gate = 100 - int(pick.tier) * 12
+    if (h >> 8) % 100 > rarity_gate:
+        return None
+    return pick
+
+
+def cell_snapshot(seed: str, cell_x: int, cell_z: int, depth_y: int = 48) -> dict:
+    biome = biome_at(seed, cell_x, cell_z)
+    ore = ore_at_position(seed, biome.biome_id, depth_y, cell_x, cell_z)
+    return {
+        "cell_x": cell_x,
+        "cell_z": cell_z,
+        "depth_y": depth_y,
+        "biome": biome.to_dict(),
+        "ore": ore.to_dict() if ore else None,
+    }

--- a/cpow_engine/world/hazards.py
+++ b/cpow_engine/world/hazards.py
@@ -1,0 +1,73 @@
+"""바이옴 위험 주기 — 소리 예고 단계."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from cpow_engine.world.biomes import BIOME_CATALOG, BiomeDef, HazardPhase
+
+
+@dataclass
+class HazardState:
+    phase_index: int = 0
+    tick_in_phase: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "phase_index": self.phase_index,
+            "tick_in_phase": self.tick_in_phase,
+        }
+
+
+_PHASE_TICKS = 120
+
+
+def advance_hazard(state: HazardState, biome: BiomeDef) -> HazardState:
+    state.tick_in_phase += 1
+    if state.tick_in_phase >= _PHASE_TICKS:
+        state.tick_in_phase = 0
+        state.phase_index = (state.phase_index + 1) % max(1, len(biome.phases))
+    return state
+
+
+def hazard_phase_for(biome: BiomeDef, state: HazardState) -> HazardPhase:
+    phases = biome.phases or ("calm",)
+    phase_id = phases[state.phase_index % len(phases)]
+    danger = 0
+    if "warning" in phase_id:
+        danger = 2
+    elif phase_id not in ("calm", "harvest", "growth", "tide_low"):
+        danger = 3 if "eruption" in phase_id or "tsunami" in phase_id else 2
+    audio = biome.hazard_audio.get(phase_id, "")
+    stage = "distant"
+    if "warning" in phase_id:
+        stage = "warning"
+        seconds = max(0.0, (_PHASE_TICKS - state.tick_in_phase) * 1.0)
+    elif danger >= 3:
+        stage = "imminent"
+        seconds = 0.0
+    else:
+        seconds = 0.0
+    return HazardPhase(
+        phase_id=phase_id,
+        label=phase_id,
+        danger_level=danger,
+        audio_cue=audio,
+        audio_stage=stage,
+        seconds_to_event=seconds,
+    )
+
+
+def hazard_snapshot(biome: BiomeDef, state: HazardState) -> dict:
+    phase = hazard_phase_for(biome, state)
+    return {
+        "phase": {
+            "phase_id": phase.phase_id,
+            "label": phase.label,
+            "danger_level": phase.danger_level,
+            "audio_cue": phase.audio_cue,
+            "audio_stage": phase.audio_stage,
+            "seconds_to_event": phase.seconds_to_event,
+        },
+        "state": state.to_dict(),
+    }

--- a/cpow_engine/world/mining.py
+++ b/cpow_engine/world/mining.py
@@ -1,0 +1,154 @@
+"""채굴 숙련·시도 — 도구·경도·바이옴."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from cpow_engine.models import CreativeObject, PropertyDef
+from cpow_engine.world.ores import ORE_CATALOG, OreDef, OreSource
+from cpow_engine.world.tools import ToolDef, ToolType, resolve_tool
+
+
+_MINING_TIER_THRESHOLDS: tuple[tuple[float, int], ...] = (
+    (100.0, 2),
+    (500.0, 3),
+    (2000.0, 4),
+    (8000.0, 5),
+    (25000.0, 6),
+)
+
+
+@dataclass
+class MiningProfile:
+    user_id: str
+    xp: float = 0.0
+    tier: int = 1
+    totals: dict[str, float] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "user_id": self.user_id,
+            "xp": round(self.xp, 2),
+            "tier": self.tier,
+            "totals": dict(self.totals),
+        }
+
+
+def tier_from_xp(xp: float) -> int:
+    tier = 1
+    for threshold, value in _MINING_TIER_THRESHOLDS:
+        if xp >= threshold:
+            tier = value
+    return tier
+
+
+def apply_mining_xp(profile: MiningProfile, ore_id: str, amount: float) -> None:
+    profile.totals[ore_id] = profile.totals.get(ore_id, 0.0) + amount
+    profile.xp += amount * (1.0 + ORE_CATALOG[ore_id].tier * 0.5)
+    profile.tier = tier_from_xp(profile.xp)
+
+
+@dataclass
+class MineAttemptResult:
+    ok: bool
+    reason: str = ""
+    ore_id: str = ""
+    amount: float = 0.0
+    resource: dict | None = None
+    mining: dict | None = None
+
+    def to_dict(self) -> dict:
+        out: dict = {
+            "ok": self.ok,
+            "reason": self.reason,
+            "ore_id": self.ore_id,
+            "amount": self.amount,
+        }
+        if self.resource:
+            out["resource"] = self.resource
+        if self.mining:
+            out["mining"] = self.mining
+        return out
+
+
+def _yield_amount(
+    ore: OreDef,
+    tool: ToolDef,
+    profile: MiningProfile,
+    *,
+    hazard_penalty: float = 0.0,
+) -> float:
+    tier_bonus = 1.0 + profile.tier * 0.05
+    base = ore.base_yield * tool.mining_power * tier_bonus
+    if tool.tool_type == ToolType.DRILL and ore.hardness >= 4:
+        base *= 1.15
+    if tool.tool_type == ToolType.PICKAXE and ore.hardness >= 5:
+        base *= 0.05
+    base *= max(0.2, 1.0 - hazard_penalty)
+    return max(0.0, round(base, 3))
+
+
+def validate_mine_tool(ore: OreDef, tool: ToolDef) -> tuple[bool, str]:
+    if ore.hardness > tool.max_hardness:
+        return False, "tool_too_weak"
+    if ore.tier >= 4 and tool.tool_type == ToolType.PICKAXE:
+        return False, "requires_drill"
+    if ore.ore_id == "black_mithril_ore" and tool.mining_tier < 6:
+        return False, "requires_black_mithril_drill"
+    return True, "ok"
+
+
+def attempt_mine(
+    *,
+    actor_id: str,
+    ore: OreDef,
+    tool: ToolDef,
+    profile: MiningProfile,
+    consumable: str = "",
+    hazard_danger: int = 0,
+) -> MineAttemptResult:
+    if ore.source == OreSource.BOSS:
+        return MineAttemptResult(False, reason="boss_drop_only")
+    if ore.requires_consumable and consumable != ore.requires_consumable:
+        return MineAttemptResult(False, reason="missing_consumable")
+    ok, reason = validate_mine_tool(ore, tool)
+    if not ok:
+        return MineAttemptResult(False, reason=reason)
+    penalty = 0.15 * max(0, hazard_danger - 1)
+    amount = _yield_amount(ore, tool, profile, hazard_penalty=penalty)
+    if amount <= 0.0:
+        return MineAttemptResult(False, reason="no_yield")
+    apply_mining_xp(profile, ore.ore_id, amount)
+    resource = build_resource_object(actor_id, ore.ore_id, amount).to_dict()
+    return MineAttemptResult(
+        True,
+        reason="mined",
+        ore_id=ore.ore_id,
+        amount=amount,
+        resource=resource,
+        mining=profile.to_dict(),
+    )
+
+
+def build_resource_object(actor_id: str, ore_id: str, amount: float) -> CreativeObject:
+    ore = ORE_CATALOG[ore_id]
+    return CreativeObject(
+        creator_id=actor_id,
+        label=ore.label,
+        properties=[
+            PropertyDef("material_type", 0.0, ore_id),
+            PropertyDef("purpose", 0.0, "resource"),
+            PropertyDef("stack_amount", amount, "units"),
+            PropertyDef("material_tier", float(int(ore.tier)), "tier"),
+            PropertyDef("source", 0.0, ore.source.value),
+        ],
+    )
+
+
+def parse_tool_from_payload(payload: dict) -> ToolDef:
+    tool_type = str(payload.get("tool_type", "pickaxe"))
+    tier = int(payload.get("tool_tier", payload.get("mining_tier", 1)))
+    tool = resolve_tool(tool_type, tier)
+    if tool is None:
+        return resolve_tool("pickaxe", 1)  # type: ignore[return-value]
+    return tool

--- a/cpow_engine/world/ores.py
+++ b/cpow_engine/world/ores.py
@@ -1,0 +1,117 @@
+"""광물·자재 정의 — 티어·경도·바이옴."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from cpow_engine.world.biomes import BiomeId
+
+
+class MaterialTier(int, Enum):
+    T0 = 0
+    T1 = 1
+    T2 = 2
+    T3 = 3
+    T4 = 4
+    T5 = 5
+    T6 = 6
+
+
+class OreSource(str, Enum):
+    VEIN = "vein"
+    MOB = "mob"
+    BOSS = "boss"
+    CRAFT = "craft"
+
+
+@dataclass(frozen=True)
+class OreDef:
+    ore_id: str
+    label: str
+    tier: MaterialTier
+    hardness: int
+    base_yield: float
+    biomes: frozenset[BiomeId]
+    min_depth: int = 0
+    max_depth: int = 256
+    source: OreSource = OreSource.VEIN
+    requires_consumable: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "ore_id": self.ore_id,
+            "label": self.label,
+            "tier": int(self.tier),
+            "hardness": self.hardness,
+            "base_yield": self.base_yield,
+            "biomes": sorted(b.value for b in self.biomes),
+            "min_depth": self.min_depth,
+            "max_depth": self.max_depth,
+            "source": self.source.value,
+            "requires_consumable": self.requires_consumable,
+        }
+
+
+ORE_CATALOG: dict[str, OreDef] = {
+    "dirt": OreDef("dirt", "흙", MaterialTier.T0, 1, 4.0, frozenset({BiomeId.PLAINS, BiomeId.FOREST}), 0, 32),
+    "stone": OreDef("stone", "돌", MaterialTier.T0, 1, 3.0, frozenset(BiomeId), 0, 64),
+    "coal": OreDef("coal", "석탄", MaterialTier.T1, 2, 2.5, frozenset({BiomeId.MINE, BiomeId.HILLS, BiomeId.PLAINS}), 16, 96),
+    "copper_ore": OreDef(
+        "copper_ore", "구리 광석", MaterialTier.T1, 2, 2.0,
+        frozenset({BiomeId.HILLS, BiomeId.PLAINS, BiomeId.MINE}), 20, 80,
+    ),
+    "iron_ore": OreDef(
+        "iron_ore", "철 광석", MaterialTier.T2, 3, 1.8,
+        frozenset({BiomeId.HILLS, BiomeId.MINE, BiomeId.PLAINS}), 32, 128,
+    ),
+    "silver_ore": OreDef(
+        "silver_ore", "은 광석", MaterialTier.T3, 4, 1.2,
+        frozenset({BiomeId.HILLS, BiomeId.MINE}), 56, 160,
+    ),
+    "gold_ore": OreDef(
+        "gold_ore", "금 광석", MaterialTier.T3, 4, 1.0,
+        frozenset({BiomeId.HILLS, BiomeId.MINE}), 64, 180,
+    ),
+    "diamond_ore": OreDef(
+        "diamond_ore", "다이아 광석", MaterialTier.T4, 5, 0.6,
+        frozenset(BiomeId), 80, 256,
+    ),
+    "sapphire_ore": OreDef(
+        "sapphire_ore", "사파이어", MaterialTier.T4, 5, 0.5,
+        frozenset({BiomeId.MINE, BiomeId.RIFT}), 72, 200,
+    ),
+    "emerald_ore": OreDef(
+        "emerald_ore", "에메랄드", MaterialTier.T4, 5, 0.45,
+        frozenset({BiomeId.FOREST, BiomeId.RIFT}), 70, 190,
+    ),
+    "frost_crystal": OreDef(
+        "frost_crystal", "서리 결정", MaterialTier.T4, 4, 0.8,
+        frozenset({BiomeId.ALPINE}), 40, 160,
+    ),
+    "sulfur": OreDef(
+        "sulfur", "황", MaterialTier.T3, 4, 1.1,
+        frozenset({BiomeId.VOLCANO}), 20, 120,
+    ),
+    "pearl": OreDef(
+        "pearl", "진주", MaterialTier.T3, 3, 0.7,
+        frozenset({BiomeId.OCEAN, BiomeId.COAST}), 0, 40, source=OreSource.VEIN,
+    ),
+    "mithril_ore": OreDef(
+        "mithril_ore", "미스릴 광석", MaterialTier.T5, 6, 0.35,
+        frozenset({BiomeId.ALPINE, BiomeId.RIFT, BiomeId.VOLCANO}), 90, 256,
+    ),
+    "black_mithril_shard": OreDef(
+        "black_mithril_shard", "블랙미스릴 파편", MaterialTier.T6, 7, 0.15,
+        frozenset({BiomeId.RIFT}), source=OreSource.BOSS,
+    ),
+    "black_mithril_ore": OreDef(
+        "black_mithril_ore", "블랙미스릴 광석", MaterialTier.T6, 7, 0.12,
+        frozenset({BiomeId.RIFT}), 100, 256,
+        requires_consumable="void_stabilizer",
+    ),
+}
+
+
+def ore_catalog_public() -> list[dict]:
+    return [o.to_dict() for o in ORE_CATALOG.values()]

--- a/cpow_engine/world/service.py
+++ b/cpow_engine/world/service.py
@@ -1,0 +1,158 @@
+"""월드 서비스 — 바이옴·채굴·건축·위험."""
+
+from __future__ import annotations
+
+from cpow_engine.world.biomes import biome_catalog_public
+from cpow_engine.world.building import (
+    blueprint_catalog_public,
+    validate_blueprint_placement,
+)
+from cpow_engine.world.grid import biome_at, cell_from_world, cell_snapshot, ore_at_position
+from cpow_engine.world.hazards import advance_hazard, hazard_snapshot
+from cpow_engine.world.mining import attempt_mine, parse_tool_from_payload
+from cpow_engine.world.ores import ORE_CATALOG, ore_catalog_public
+from cpow_engine.world.state import AreaWorldRuntime
+from cpow_engine.world.tools import tool_catalog_public
+
+
+class WorldService:
+    def __init__(self) -> None:
+        self._areas: dict[str, AreaWorldRuntime] = {}
+
+    def runtime_for(self, area_id: str) -> AreaWorldRuntime:
+        if area_id not in self._areas:
+            self._areas[area_id] = AreaWorldRuntime(
+                area_id=area_id,
+                world_seed=area_id,
+            )
+        return self._areas[area_id]
+
+    def catalog(self) -> dict:
+        return {
+            "ok": True,
+            "biomes": biome_catalog_public(),
+            "ores": ore_catalog_public(),
+            "tools": tool_catalog_public(),
+            "blueprints": blueprint_catalog_public(),
+        }
+
+    def inspect_cell(
+        self,
+        area_id: str,
+        *,
+        x: float,
+        z: float,
+        depth_y: int = 48,
+        cell_size: int = 64,
+        advance_tick: bool = False,
+    ) -> dict:
+        runtime = self.runtime_for(area_id)
+        cx, cz = cell_from_world(x, z, cell_size)
+        biome = biome_at(runtime.world_seed, cx, cz)
+        hazard_st = runtime.hazard_state_for(cx, cz)
+        if advance_tick:
+            runtime.world_tick += 1
+            advance_hazard(hazard_st, biome)
+        snap = cell_snapshot(runtime.world_seed, cx, cz, depth_y)
+        snap["hazard"] = hazard_snapshot(biome, hazard_st)
+        snap["ok"] = True
+        snap["area_id"] = area_id
+        return snap
+
+    def mine(
+        self,
+        area_id: str,
+        payload: dict,
+    ) -> dict:
+        runtime = self.runtime_for(area_id)
+        actor_id = str(payload.get("actor_id", "anonymous"))
+        x = float(payload.get("x", 0.0))
+        z = float(payload.get("z", 0.0))
+        depth_y = int(payload.get("depth_y", 48))
+        cell_size = int(payload.get("cell_size", 64))
+        ore_id = payload.get("ore_id")
+        consumable = str(payload.get("consumable", ""))
+
+        cx, cz = cell_from_world(x, z, cell_size)
+        biome = biome_at(runtime.world_seed, cx, cz)
+        hazard_st = runtime.hazard_state_for(cx, cz)
+        from cpow_engine.world.hazards import hazard_phase_for
+
+        phase = hazard_phase_for(biome, hazard_st)
+
+        if ore_id:
+            ore = ORE_CATALOG.get(str(ore_id))
+        else:
+            ore = ore_at_position(runtime.world_seed, biome.biome_id, depth_y, cx, cz)
+        if ore is None:
+            return {"ok": False, "reason": "no_ore_here", "area_id": area_id}
+
+        tool = parse_tool_from_payload(payload)
+        profile = runtime.miner_profile(actor_id)
+        result = attempt_mine(
+            actor_id=actor_id,
+            ore=ore,
+            tool=tool,
+            profile=profile,
+            consumable=consumable,
+            hazard_danger=phase.danger_level,
+        )
+        out = result.to_dict()
+        out["area_id"] = area_id
+        out["biome_id"] = biome.biome_id.value
+        out["hazard_audio"] = {
+            "audio_cue": phase.audio_cue,
+            "audio_stage": phase.audio_stage,
+            "phase_id": phase.phase_id,
+        }
+        return out
+
+    def validate_build(self, payload: dict) -> dict:
+        area_id = str(payload.get("area_id", ""))
+        biome_id = str(payload.get("biome_id", "plains"))
+        blueprint_id = str(payload.get("blueprint_id", ""))
+        placed_modules = {
+            str(k): int(v)
+            for k, v in dict(payload.get("placed_modules", {})).items()
+        }
+        placed_materials = {
+            str(k): int(v)
+            for k, v in dict(payload.get("placed_materials", {})).items()
+        }
+        civ = int(payload.get("civilization_level", 0))
+        result = validate_blueprint_placement(
+            biome_id=biome_id,
+            blueprint_id=blueprint_id,
+            placed_modules=placed_modules,
+            placed_materials=placed_materials,
+            civilization_level=civ,
+        )
+        out = result.to_dict()
+        out["ok"] = result.ok
+        out["area_id"] = area_id
+        return out
+
+    def boss_loot(self, area_id: str, payload: dict) -> dict:
+        """균열 보스 — 블랙미스릴 파편 시드."""
+        runtime = self.runtime_for(area_id)
+        actor_id = str(payload.get("actor_id", "anonymous"))
+        from cpow_engine.world.mining import build_resource_object, apply_mining_xp
+
+        ore = ORE_CATALOG["black_mithril_shard"]
+        profile = runtime.miner_profile(actor_id)
+        amount = float(payload.get("amount", 1.0))
+        apply_mining_xp(profile, ore.ore_id, amount)
+        return {
+            "ok": True,
+            "reason": "boss_loot",
+            "area_id": area_id,
+            "resource": build_resource_object(actor_id, ore.ore_id, amount).to_dict(),
+            "mining": profile.to_dict(),
+        }
+
+
+_DEFAULT = WorldService()
+
+
+def get_world_service() -> WorldService:
+    return _DEFAULT

--- a/cpow_engine/world/state.py
+++ b/cpow_engine/world/state.py
@@ -1,0 +1,37 @@
+"""에리어 월드 런타임 상태."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from cpow_engine.world.hazards import HazardState
+from cpow_engine.world.mining import MiningProfile
+
+
+@dataclass
+class AreaWorldRuntime:
+    area_id: str
+    world_seed: str
+    cell_hazards: dict[tuple[int, int], HazardState] = field(default_factory=dict)
+    miners: dict[str, MiningProfile] = field(default_factory=dict)
+    world_tick: int = 0
+
+    def hazard_state_for(self, cell_x: int, cell_z: int) -> HazardState:
+        key = (cell_x, cell_z)
+        if key not in self.cell_hazards:
+            self.cell_hazards[key] = HazardState()
+        return self.cell_hazards[key]
+
+    def miner_profile(self, user_id: str) -> MiningProfile:
+        if user_id not in self.miners:
+            self.miners[user_id] = MiningProfile(user_id=user_id)
+        return self.miners[user_id]
+
+    def to_dict(self) -> dict:
+        return {
+            "area_id": self.area_id,
+            "world_seed": self.world_seed,
+            "world_tick": self.world_tick,
+            "miner_count": len(self.miners),
+            "hazard_cells": len(self.cell_hazards),
+        }

--- a/cpow_engine/world/tools.py
+++ b/cpow_engine/world/tools.py
@@ -1,0 +1,61 @@
+"""채굴 도구 — 곡괭이·드릴 티어."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ToolType(str, Enum):
+    PICKAXE = "pickaxe"
+    DRILL = "drill"
+
+
+@dataclass(frozen=True)
+class ToolDef:
+    tool_type: ToolType
+    mining_tier: int
+    mining_power: float
+    max_hardness: int
+    label: str
+
+    def to_dict(self) -> dict:
+        return {
+            "tool_type": self.tool_type.value,
+            "mining_tier": self.mining_tier,
+            "mining_power": self.mining_power,
+            "max_hardness": self.max_hardness,
+            "label": self.label,
+        }
+
+
+def resolve_tool(tool_type: str, mining_tier: int) -> ToolDef | None:
+    try:
+        kind = ToolType(tool_type.lower())
+    except ValueError:
+        return None
+    tier = max(0, min(6, int(mining_tier)))
+    if kind == ToolType.PICKAXE:
+        power = 1.0 + tier * 0.12
+        max_hard = 2 + tier
+        labels = ("나무 곡괭이", "돌 곡괭이", "철 곡괭이", "강철 곡괭이", "미스릴 곡괭이")
+        label = labels[min(tier, len(labels) - 1)]
+        return ToolDef(kind, tier, power, max_hard, label)
+    power = 1.2 + tier * 0.18
+    max_hard = 3 + tier
+    labels = (
+        "기본 드릴", "철 드릴", "강화 드릴", "다이아 비트 드릴",
+        "미스릴 드릴", "지열 드릴", "블랙미스릴 드릴",
+    )
+    label = labels[min(tier, len(labels) - 1)]
+    return ToolDef(kind, tier, power, max_hard, label)
+
+
+def tool_catalog_public() -> list[dict]:
+    out: list[dict] = []
+    for kind in ToolType:
+        for tier in range(7):
+            tool = resolve_tool(kind.value, tier)
+            if tool:
+                out.append(tool.to_dict())
+    return out

--- a/docs/PUSH_CPOW_DEPLOY_KEY.md
+++ b/docs/PUSH_CPOW_DEPLOY_KEY.md
@@ -1,0 +1,25 @@
+# cpow_world 최초 push — Deploy Key (1회)
+
+Cursor bot은 `weed97/cpow_world`에 쓰기 권한이 없습니다.  
+**아래 공개키를 repo에 등록**하면 에이전트가 SSH로 push 합니다.
+
+## 모바일에서 30초
+
+1. https://github.com/weed97/cpow_world/settings/keys  
+2. **Add deploy key**  
+3. Title: `cloud-agent-push`  
+4. Key (아래 전체 복사):
+
+```
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICXxx15zC/KHCT2pMK8MjHWwXyds+l1bWgRrZ+dR1Ptn cpow-world-push
+```
+
+5. ✅ **Allow write access** 체크  
+6. **Add key**
+
+등록 후 채팅에 **「키 추가함」** 이라고 보내 주세요.
+
+## 또는 Actions (토큰 이미 있으면)
+
+https://github.com/weed97/test1/actions/workflows/publish-cpow-world.yml  
+→ Run workflow → Branch **main**

--- a/tests/test_cpow_api_flow.py
+++ b/tests/test_cpow_api_flow.py
@@ -125,6 +125,106 @@ class TestCpowGodotClientFlow(unittest.TestCase):
 
 
 @unittest.skipIf(not _HAS_API, "fastapi not installed")
+class TestCpowWorldApiFlow(unittest.TestCase):
+    """오픈월드 — 바이옴·채굴·건축 API 스모크."""
+
+    def setUp(self) -> None:
+        self.client = TestClient(app)  # type: ignore[arg-type]
+
+    def test_world_catalog_and_cell(self) -> None:
+        catalog = self.client.get("/v1/world/catalog")
+        self.assertEqual(catalog.status_code, 200)
+        body = catalog.json()
+        self.assertTrue(body.get("ok"))
+        self.assertIn("biomes", body)
+        self.assertIn("ores", body)
+
+        found = self.client.post(
+            "/v1/areas/found",
+            json={"founder_id": "world_u", "label": "월드 테스트"},
+        )
+        area_id = found.json()["area"]["area_id"]
+
+        cell = self.client.post(
+            "/v1/world/cell",
+            json={"area_id": area_id, "x": 64.0, "z": -32.0, "advance_tick": True},
+        )
+        self.assertEqual(cell.status_code, 200, cell.json())
+        self.assertTrue(cell.json().get("ok"), cell.json())
+        self.assertIn("hazard", cell.json())
+
+    def test_world_mine_and_adventure_mine(self) -> None:
+        found = self.client.post(
+            "/v1/areas/found",
+            json={"founder_id": "miner_u", "label": "채굴 테스트"},
+        )
+        area_id = found.json()["area"]["area_id"]
+
+        mined = self.client.post(
+            "/v1/world/mine",
+            json={
+                "area_id": area_id,
+                "actor_id": "miner_u",
+                "x": 10.0,
+                "z": 10.0,
+                "depth_y": 40,
+                "tool_type": "pickaxe",
+                "tool_tier": 2,
+                "ore_id": "coal",
+            },
+        )
+        self.assertEqual(mined.status_code, 200, mined.json())
+        self.assertTrue(mined.json().get("ok"), mined.json())
+
+        adventure = self.client.post(
+            "/v1/areas/adventure",
+            json={
+                "area_id": area_id,
+                "actor_id": "miner_u",
+                "action": "mine",
+                "x": 10.0,
+                "z": 10.0,
+                "depth_y": 40,
+                "tool_type": "pickaxe",
+                "tool_tier": 2,
+                "ore_id": "coal",
+            },
+        )
+        self.assertEqual(adventure.status_code, 200, adventure.json())
+        self.assertTrue(adventure.json().get("ok"), adventure.json())
+        self.assertEqual(adventure.json().get("action"), "mine")
+
+    def test_world_build_validate_and_boss_loot(self) -> None:
+        build = self.client.post(
+            "/v1/world/build/validate",
+            json={
+                "biome_id": "desert",
+                "blueprint_id": "camp_kit",
+                "placed_modules": {
+                    "foundation_1x1": 1,
+                    "wall_t1": 4,
+                    "heater_core": 1,
+                },
+                "placed_materials": {"wood_plank": 8, "stone_brick": 4},
+            },
+        )
+        self.assertEqual(build.status_code, 200, build.json())
+        self.assertTrue(build.json().get("ok"), build.json())
+
+        found = self.client.post(
+            "/v1/areas/found",
+            json={"founder_id": "boss_u", "label": "보스 루트"},
+        )
+        area_id = found.json()["area"]["area_id"]
+        loot = self.client.post(
+            "/v1/world/boss_loot",
+            json={"area_id": area_id, "actor_id": "boss_u", "amount": 1.0},
+        )
+        self.assertEqual(loot.status_code, 200, loot.json())
+        self.assertTrue(loot.json().get("ok"), loot.json())
+
+
+@unittest.skipIf(not _HAS_API, "fastapi not installed")
 class TestCpowAuthFlow(unittest.TestCase):
     def setUp(self) -> None:
         self.client = TestClient(app)  # type: ignore[arg-type]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the first implementation slice for the CPoW 3D open-world design: deterministic biomes, ore/mining with tool tiers, hazard audio cues, and modular blueprint validation.

## What's included

### Engine (`cpow_engine/world/`)
- **biomes** — 10 biomes with safe/buffer/danger zones, seasonal phases, hazard audio metadata
- **ores** — material catalog from dirt through black mithril (boss seed + consumable flow)
- **tools** — pickaxe and drill tiers (mining tier 0–6)
- **grid** — deterministic `biome_at`, `ore_at_position`, `cell_snapshot`
- **hazards** — phase cycling with 3-stage audio warning (`audio_cue`, `seconds_to_event`)
- **mining** — `attempt_mine`, tool validation, XP/tier progression, `CreativeObject` resource output
- **building** — blueprint validation (`camp_kit`, `smelter_lv1`, `power_line`) with zone rules
- **service** — `WorldService` facade for catalog, cell inspect, mine, build validate, boss loot

### API
- `GET /v1/world/catalog`
- `POST /v1/world/cell`
- `POST /v1/world/mine`
- `POST /v1/world/build/validate`
- `POST /v1/world/boss_loot`
- `POST /v1/areas/adventure` with `action: "mine"` delegates to world mining

### Tests
- `cpow_engine/tests/test_world.py` — grid, mining tiers, building zones, service
- `tests/test_cpow_api_flow.py` — world API smoke + adventure mine path

## Test plan
- [x] `python3 -m unittest discover -s cpow_engine/tests -v` (175 tests)
- [x] `python3 -m unittest discover -s tests -p test_cpow_api_flow.py -v` (12 tests)

## Not in this PR (follow-ups)
- ChunkStore / AOI streaming
- Mining results submitted into area `CreativeObject` pulse
- Survival gauges (hunger/warmth)
- Unity/Godot client wiring
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f2b450d-0aad-4b1b-8498-a8fcb841156a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f2b450d-0aad-4b1b-8498-a8fcb841156a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

