### PR TITLE
feat(world): inventory SoA, world drops, AOI WebSocket stream

### DIFF
--- a/cpow_api/server.py
+++ b/cpow_api/server.py
@@ -8,7 +8,7 @@ import cpow_api._bootstrap  # noqa: F401
 from pathlib import Path
 from typing import Any, Optional
 
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
@@ -62,8 +62,12 @@ from cpow_api.world import (
     handle_world_build_validate,
     handle_world_catalog,
     handle_world_cell,
+    handle_world_drops,
+    handle_world_inventory,
     handle_world_mine,
+    handle_world_pickup,
 )
+from cpow_api.stream import world_stream_websocket
 from cpow_api.route_helpers import authed_call, authed_call_400, authed_call_404
 from cpow_api.xr import _store as _xr_store
 from cpow_api.xr import handle_xr_connect, handle_xr_creation, handle_xr_world
@@ -254,7 +258,22 @@ class WorldMineRequest(BaseModel):
     tool_tier: int = 1
     ore_id: Optional[str] = None
     consumable: Optional[str] = None
-    submit_to_area: bool = True
+    deposit_mode: str = "inventory"
+    spawn_world_drop: bool = True
+    submit_to_area: bool = False
+
+
+class WorldDropsRequest(BaseModel):
+    area_id: str
+    x: float = 0.0
+    z: float = 0.0
+    radius_m: float = 128.0
+
+
+class WorldPickupRequest(BaseModel):
+    area_id: str
+    actor_id: str = "anonymous"
+    drop_id: str
 
 
 class WorldBuildValidateRequest(BaseModel):
@@ -619,6 +638,31 @@ def world_mine(
     return authed_call(
         handle_world_mine, body, auth_user, "actor_id", exclude_none=True,
     )
+
+
+@app.get("/v1/world/inventory")
+def world_inventory(area_id: str, actor_id: str = "anonymous") -> dict[str, Any]:
+    return handle_world_inventory(area_id, actor_id)
+
+
+@app.post("/v1/world/drops")
+def world_drops(body: WorldDropsRequest) -> dict[str, Any]:
+    return handle_world_drops(body.model_dump())
+
+
+@app.post("/v1/world/pickup")
+def world_pickup(
+    body: WorldPickupRequest,
+    auth_user: str | None = Depends(optional_user),
+) -> dict[str, Any]:
+    return authed_call(
+        handle_world_pickup, body, auth_user, "actor_id", exclude_none=True,
+    )
+
+
+@app.websocket("/v1/world/stream")
+async def world_stream(ws: WebSocket) -> None:
+    await world_stream_websocket(ws)
 
 
 @app.post("/v1/world/build/validate")

--- a/cpow_api/stream.py
+++ b/cpow_api/stream.py
@@ -1,0 +1,90 @@
+"""WebSocket — /v1/world/stream AOI delta."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+
+from fastapi import WebSocket, WebSocketDisconnect
+
+from cpow_engine.world.service import get_world_service
+from cpow_engine.world.stream_hub import StreamSubscription, get_stream_hub
+
+
+async def world_stream_websocket(websocket: WebSocket) -> None:
+    await websocket.accept()
+    hub = get_stream_hub()
+    conn_id = f"ws_{uuid.uuid4().hex[:10]}"
+    sub: StreamSubscription | None = None
+
+    async def wait_subscribe() -> StreamSubscription:
+        while True:
+            raw = await websocket.receive_text()
+            msg = json.loads(raw)
+            if str(msg.get("type", "")).lower() != "subscribe":
+                await websocket.send_text(json.dumps({
+                    "type": "error",
+                    "reason": "expected_subscribe",
+                }))
+                continue
+            area_id = str(msg.get("area_id", ""))
+            if not area_id:
+                await websocket.send_text(json.dumps({
+                    "type": "error",
+                    "reason": "missing_area_id",
+                }))
+                continue
+            subscription = StreamSubscription(
+                connection_id=conn_id,
+                area_id=area_id,
+                actor_id=str(msg.get("actor_id", "anonymous")),
+                x=float(msg.get("x", 0.0)),
+                z=float(msg.get("z", 0.0)),
+                radius_m=float(msg.get("radius_m", 128.0)),
+            )
+            await hub.subscribe(subscription)
+            svc = get_world_service()
+            await websocket.send_text(json.dumps({
+                "type": "subscribed",
+                "connection_id": conn_id,
+                "area_id": area_id,
+                "inventory": svc.get_inventory(area_id, subscription.actor_id).get("inventory", {}),
+                "drops": svc.drops_in_aoi(
+                    area_id, subscription.x, subscription.z, subscription.radius_m,
+                ).get("drops", []),
+            }, ensure_ascii=False))
+            return subscription
+
+    async def reader() -> None:
+        nonlocal sub
+        assert sub is not None
+        while True:
+            raw = await websocket.receive_text()
+            msg = json.loads(raw)
+            mtype = str(msg.get("type", "")).lower()
+            if mtype == "pose":
+                await hub.update_pose(
+                    conn_id,
+                    float(msg.get("x", sub.x)),
+                    float(msg.get("z", sub.z)),
+                    float(msg["radius_m"]) if "radius_m" in msg else None,
+                )
+                sub.x = float(msg.get("x", sub.x))
+                sub.z = float(msg.get("z", sub.z))
+            elif mtype == "ping":
+                await websocket.send_text(json.dumps({"type": "pong"}))
+
+    async def writer() -> None:
+        while True:
+            event = await hub.drain(conn_id, timeout=25.0)
+            if event:
+                await websocket.send_text(json.dumps(event, ensure_ascii=False))
+
+    try:
+        sub = await wait_subscribe()
+        await asyncio.gather(reader(), writer())
+    except (WebSocketDisconnect, asyncio.CancelledError):
+        pass
+    finally:
+        await hub.unsubscribe(conn_id)

--- a/cpow_api/world.py
+++ b/cpow_api/world.py
@@ -7,8 +7,15 @@ from typing import Any
 from cpow_engine.world.service import get_world_service
 
 
-def _maybe_submit_mined_resource(payload: dict[str, Any], out: dict[str, Any]) -> dict[str, Any]:
+def _should_submit_area_object(payload: dict[str, Any]) -> bool:
     if payload.get("submit_to_area") is False:
+        return False
+    deposit = str(payload.get("deposit_mode", "inventory")).lower()
+    return deposit in ("area_object", "both")
+
+
+def _maybe_submit_mined_resource(payload: dict[str, Any], out: dict[str, Any]) -> dict[str, Any]:
+    if not _should_submit_area_object(payload):
         return out
     if not out.get("ok") or not out.get("resource"):
         return out
@@ -37,6 +44,31 @@ def handle_world_cell(payload: dict[str, Any]) -> dict[str, Any]:
         cell_size=int(payload.get("cell_size", 64)),
         advance_tick=bool(payload.get("advance_tick", False)),
     )
+
+
+def handle_world_inventory(area_id: str, actor_id: str) -> dict[str, Any]:
+    if not area_id:
+        return {"ok": False, "reason": "missing_area_id"}
+    return get_world_service().get_inventory(area_id, actor_id)
+
+
+def handle_world_drops(payload: dict[str, Any]) -> dict[str, Any]:
+    area_id = str(payload.get("area_id", ""))
+    if not area_id:
+        return {"ok": False, "reason": "missing_area_id"}
+    return get_world_service().drops_in_aoi(
+        area_id,
+        float(payload.get("x", 0.0)),
+        float(payload.get("z", 0.0)),
+        float(payload.get("radius_m", 128.0)),
+    )
+
+
+def handle_world_pickup(payload: dict[str, Any]) -> dict[str, Any]:
+    area_id = str(payload.get("area_id", ""))
+    if not area_id:
+        return {"ok": False, "reason": "missing_area_id"}
+    return get_world_service().pickup_drop(area_id, payload)
 
 
 def handle_world_mine(payload: dict[str, Any]) -> dict[str, Any]:

--- a/cpow_client/unity/CPoWWorld/Assets/CPoW/Scripts/Net/WorldApiClient.cs
+++ b/cpow_client/unity/CPoWWorld/Assets/CPoW/Scripts/Net/WorldApiClient.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using System.Text;
 using System.Threading;
@@ -75,6 +76,12 @@ namespace CPoW.Net
             sb.Append('}');
             return HttpJson.PostAsync(Url("/v1/world/boss_loot"), sb.ToString(), ct);
         }
+
+        public Task<string> GetInventoryAsync(string areaId, string actorId, CancellationToken ct = default)
+            => HttpJson.GetAsync(
+                Url("/v1/world/inventory?area_id=" + Uri.EscapeDataString(areaId)
+                    + "&actor_id=" + Uri.EscapeDataString(actorId)),
+                ct);
 
         static string Escape(string s) => s.Replace("\\", "\\\\").Replace("\"", "\\\"");
     }

--- a/cpow_client/unity/CPoWWorld/Assets/CPoW/Scripts/Net/WorldStreamClient.cs
+++ b/cpow_client/unity/CPoWWorld/Assets/CPoW/Scripts/Net/WorldStreamClient.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Concurrent;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CPoW.Net;
+using UnityEngine;
+
+namespace CPoW.Net
+{
+    /// <summary>WebSocket /v1/world/stream — AOI inventory & drop deltas.</summary>
+    public sealed class WorldStreamClient : MonoBehaviour
+    {
+        readonly ConcurrentQueue<string> _inbox = new();
+        ClientWebSocket _socket;
+        CancellationTokenSource _cts;
+        string _connectionId = "";
+
+        public event Action<string> MessageReceived;
+
+        public async Task ConnectAsync(
+            string areaId,
+            string actorId,
+            float x,
+            float z,
+            float radiusM = 128f)
+        {
+            await DisconnectAsync();
+            _cts = new CancellationTokenSource();
+            _socket = new ClientWebSocket();
+            var uri = new Uri(CpowApiConfig.BaseUrl.Replace("http://", "ws://").Replace("https://", "wss://") + "/v1/world/stream");
+            await _socket.ConnectAsync(uri, _cts.Token);
+            var sub = $"{{\"type\":\"subscribe\",\"area_id\":\"{areaId}\",\"actor_id\":\"{actorId}\",\"x\":{x:F1},\"z\":{z:F1},\"radius_m\":{radiusM:F0}}}";
+            var bytes = Encoding.UTF8.GetBytes(sub);
+            await _socket.SendAsync(bytes, WebSocketMessageType.Text, true, _cts.Token);
+            _ = Task.Run(ReceiveLoop);
+        }
+
+        async Task ReceiveLoop()
+        {
+            var buffer = new byte[8192];
+            while (_socket != null && _socket.State == WebSocketState.Open && !_cts.IsCancellationRequested)
+            {
+                try
+                {
+                    var seg = new ArraySegment<byte>(buffer);
+                    var result = await _socket.ReceiveAsync(seg, _cts.Token);
+                    if (result.MessageType == WebSocketMessageType.Close)
+                        break;
+                    var text = Encoding.UTF8.GetString(buffer, 0, result.Count);
+                    _inbox.Enqueue(text);
+                }
+                catch
+                {
+                    break;
+                }
+            }
+        }
+
+        public async Task SendPoseAsync(float x, float z)
+        {
+            if (_socket == null || _socket.State != WebSocketState.Open)
+                return;
+            var json = $"{{\"type\":\"pose\",\"x\":{x:F1},\"z\":{z:F1}}}";
+            var bytes = Encoding.UTF8.GetBytes(json);
+            await _socket.SendAsync(bytes, WebSocketMessageType.Text, true, _cts.Token);
+        }
+
+        void Update()
+        {
+            while (_inbox.TryDequeue(out var text))
+            {
+                if (text.Contains("\"type\":\"subscribed\""))
+                    _connectionId = JsonField.GetString(text, "connection_id", "");
+                MessageReceived?.Invoke(text);
+            }
+        }
+
+        public async Task DisconnectAsync()
+        {
+            if (_cts != null)
+            {
+                _cts.Cancel();
+                _cts = null;
+            }
+            if (_socket != null)
+            {
+                try
+                {
+                    if (_socket.State == WebSocketState.Open)
+                        await _socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "bye", CancellationToken.None);
+                }
+                catch { /* ignore */ }
+                _socket.Dispose();
+                _socket = null;
+            }
+        }
+
+        void OnDestroy() => _ = DisconnectAsync();
+    }
+}

--- a/cpow_client/unity/CPoWWorld/Assets/CPoW/Scripts/Runtime/GameBootstrap.cs
+++ b/cpow_client/unity/CPoWWorld/Assets/CPoW/Scripts/Runtime/GameBootstrap.cs
@@ -19,7 +19,10 @@ namespace CPoW.Runtime
         ChunkStreamer _streamer;
         AreaObjectRenderer _renderer;
         MiningController _mining;
+        WorldStreamClient _worldStream;
+        WorldDropRenderer _dropRenderer;
         float _nextPoll;
+        float _nextPose;
 
         async void Start()
         {
@@ -68,6 +71,21 @@ namespace CPoW.Runtime
                     hud = gameObject.AddComponent<CPoW.UI.MiningHud>();
                 hud.Bind(_mining);
                 _mining.MineCompleted += _ => _ = RefreshAreaStateAsync();
+                await _mining.RefreshInventoryAsync();
+
+                _dropRenderer = gameObject.GetComponent<WorldDropRenderer>();
+                if (_dropRenderer == null)
+                    _dropRenderer = gameObject.AddComponent<WorldDropRenderer>();
+
+                _worldStream = gameObject.GetComponent<WorldStreamClient>();
+                if (_worldStream == null)
+                    _worldStream = gameObject.AddComponent<WorldStreamClient>();
+                _worldStream.MessageReceived += OnStreamMessage;
+                await _worldStream.ConnectAsync(
+                    _session.AreaId,
+                    _session.UserId,
+                    playerProxy.position.x,
+                    playerProxy.position.z);
 
                 await RefreshAreaStateAsync();
             }
@@ -85,6 +103,31 @@ namespace CPoW.Runtime
                 return;
             _nextPoll = Time.time + statePollSeconds;
             await RefreshAreaStateAsync();
+        }
+
+        void OnStreamMessage(string json)
+        {
+            if (string.IsNullOrEmpty(json)) return;
+
+            if (json.Contains("\"type\":\"subscribed\""))
+            {
+                var dropsIdx = json.IndexOf("\"drops\":[", System.StringComparison.Ordinal);
+                if (dropsIdx >= 0 && _dropRenderer != null)
+                {
+                    var start = dropsIdx + "\"drops\":".Length;
+                    var end = json.IndexOf(']', start);
+                    if (end > start)
+                        _dropRenderer.SyncDropsJson(json.Substring(start, end - start + 1));
+                }
+                if (_mining != null)
+                    _mining.ApplyInventoryJson(json);
+                return;
+            }
+
+            if (_dropRenderer != null)
+                _dropRenderer.ApplyStreamJson(json);
+            if (_mining != null && json.Contains("inventory_delta"))
+                _ = _mining.RefreshInventoryAsync();
         }
 
         async Task RefreshAreaStateAsync()
@@ -110,6 +153,17 @@ namespace CPoW.Runtime
                 return;
             var move = new Vector3(dx, 0f, dz).normalized * (8f * Time.deltaTime);
             playerProxy.position += move;
+            if (_worldStream != null && Time.time >= _nextPose)
+            {
+                _nextPose = Time.time + 0.4f;
+                _ = _worldStream.SendPoseAsync(playerProxy.position.x, playerProxy.position.z);
+            }
+        }
+
+        async void OnDestroy()
+        {
+            if (_worldStream != null)
+                await _worldStream.DisconnectAsync();
         }
     }
 }

--- a/cpow_client/unity/CPoWWorld/Assets/CPoW/Scripts/UI/MiningHud.cs
+++ b/cpow_client/unity/CPoWWorld/Assets/CPoW/Scripts/UI/MiningHud.cs
@@ -88,6 +88,16 @@ namespace CPoW.UI
             GUI.enabled = true;
 
             GUILayout.Space(6);
+            GUILayout.Label("— 인벤토리 (SoA) —");
+            if (_mining.Inventory.Stacks.Count == 0)
+                GUILayout.Label("(비어 있음)");
+            else
+            {
+                foreach (var kv in _mining.Inventory.Stacks)
+                    GUILayout.Label($"  {kv.Key}: {kv.Value:F2}");
+            }
+
+            GUILayout.Space(6);
             GUILayout.Label(_mining.StatusLine, GUI.skin.box);
 
             var last = _mining.LastMine;

--- a/cpow_client/unity/CPoWWorld/Assets/CPoW/Scripts/World/MiningController.cs
+++ b/cpow_client/unity/CPoWWorld/Assets/CPoW/Scripts/World/MiningController.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using CPoW.Net;
 using CPoW.Runtime;
@@ -65,6 +66,7 @@ namespace CPoW.World
         public CellInspectResult CurrentCell { get; private set; } = new();
         public MineResult LastMine { get; private set; } = new();
         public WorldCatalogCache Catalog { get; private set; } = new();
+        public InventorySnapshot Inventory { get; private set; } = new();
         public string StatusLine { get; private set; } = "셀 조사 대기…";
 
         public event System.Action<MineResult> MineCompleted;
@@ -85,6 +87,25 @@ namespace CPoW.World
                 return;
             _nextRefresh = Time.time + cellRefreshInterval;
             _ = RefreshCellAsync();
+        }
+
+        public void ApplyInventoryJson(string json)
+        {
+            Inventory = InventorySnapshot.FromJson(json);
+        }
+
+        public async Task RefreshInventoryAsync()
+        {
+            if (_session == null || string.IsNullOrEmpty(_session.AreaId)) return;
+            try
+            {
+                var json = await _session.World.GetInventoryAsync(_session.AreaId, _session.UserId);
+                ApplyInventoryJson(json);
+            }
+            catch (System.Exception ex)
+            {
+                StatusLine = "인벤토리 조회 실패: " + ex.Message;
+            }
         }
 
         public async Task RefreshCellAsync()
@@ -144,6 +165,10 @@ namespace CPoW.World
                 LastMine = MineResult.FromJson(json);
                 if (LastMine.Ok)
                 {
+                    if (!string.IsNullOrEmpty(json) && json.Contains("\"inventory\""))
+                        ApplyInventoryJson(json);
+                    else
+                        await RefreshInventoryAsync();
                     if (LastMine.CreationOk && !string.IsNullOrEmpty(LastMine.CreationObjectId))
                         StatusLine = $"채굴+창조: {LastMine.ResourceLabel} x{LastMine.Amount:F2} → 오브젝트 {LastMine.CreationObjectId}";
                     else if (!string.IsNullOrEmpty(LastMine.CreationReason))

--- a/cpow_client/unity/CPoWWorld/Assets/CPoW/Scripts/World/MiningModels.cs
+++ b/cpow_client/unity/CPoWWorld/Assets/CPoW/Scripts/World/MiningModels.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using CPoW.Net;
 
 namespace CPoW.World
@@ -134,6 +135,47 @@ namespace CPoW.World
             cache.OreIds.AddRange(new[] { "coal", "copper_ore", "iron_ore", "diamond_ore" });
             cache.OreLabels.AddRange(new[] { "석탄", "구리 광석", "철 광석", "다이아" });
             return cache;
+        }
+    }
+
+    /// <summary>GET /v1/world/inventory stacks.</summary>
+    public sealed class InventorySnapshot
+    {
+        public readonly Dictionary<string, float> Stacks = new();
+
+        public static InventorySnapshot FromJson(string json)
+        {
+            var snap = new InventorySnapshot();
+            if (string.IsNullOrEmpty(json)) return snap;
+            var idx = 0;
+            while (idx < json.Length)
+            {
+                var i = json.IndexOf('"', idx);
+                if (i < 0) break;
+                var j = json.IndexOf('"', i + 1);
+                if (j < 0) break;
+                var key = json.Substring(i + 1, j - i - 1);
+                if (key is "actor_id" or "slot_count" or "stacks" or "inventory" or "ok")
+                {
+                    idx = j + 1;
+                    continue;
+                }
+                var colon = json.IndexOf(':', j);
+                if (colon < 0) break;
+                var end = colon + 1;
+                while (end < json.Length && (char.IsDigit(json[end]) || json[end] == '.'))
+                    end++;
+                if (float.TryParse(
+                    json.Substring(colon + 1, end - colon - 1),
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out var val) && val > 0)
+                {
+                    snap.Stacks[key] = val;
+                }
+                idx = end;
+            }
+            return snap;
         }
     }
 }

--- a/cpow_client/unity/CPoWWorld/Assets/CPoW/Scripts/World/WorldDropRenderer.cs
+++ b/cpow_client/unity/CPoWWorld/Assets/CPoW/Scripts/World/WorldDropRenderer.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using CPoW.Net;
+using UnityEngine;
+
+namespace CPoW.World
+{
+    /// <summary>AOI world drops — spawn/despawn from stream events.</summary>
+    public sealed class WorldDropRenderer : MonoBehaviour
+    {
+        readonly Dictionary<string, GameObject> _drops = new();
+
+        public void ApplyStreamJson(string json)
+        {
+            if (string.IsNullOrEmpty(json)) return;
+            if (json.Contains("\"type\":\"drop_spawn\""))
+                SpawnFromJson(json);
+            else if (json.Contains("\"type\":\"drop_despawn\""))
+                Despawn(JsonField.GetString(json, "drop_id", ""));
+        }
+
+        public void SyncDropsJson(string dropsArrayJson)
+        {
+            ClearAll();
+            if (string.IsNullOrEmpty(dropsArrayJson)) return;
+            var idx = 0;
+            while (idx < dropsArrayJson.Length)
+            {
+                var key = "\"drop_id\":\"";
+                var i = dropsArrayJson.IndexOf(key, idx, System.StringComparison.Ordinal);
+                if (i < 0) break;
+                var start = dropsArrayJson.LastIndexOf('{', i);
+                var end = dropsArrayJson.IndexOf('}', i);
+                if (start < 0 || end < 0) break;
+                SpawnFromJson(dropsArrayJson.Substring(start, end - start + 1));
+                idx = end + 1;
+            }
+        }
+
+        void SpawnFromJson(string json)
+        {
+            var id = JsonField.GetString(json, "drop_id", "");
+            if (string.IsNullOrEmpty(id) || _drops.ContainsKey(id)) return;
+            var ore = JsonField.GetString(json, "ore_id", "ore");
+            var x = JsonField.GetFloat(json, "x", 0f);
+            var z = JsonField.GetFloat(json, "z", 0f);
+            var amount = JsonField.GetFloat(json, "amount", 1f);
+
+            var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            go.name = "Drop_" + id;
+            go.transform.SetParent(transform, false);
+            go.transform.position = new Vector3(x, 0.35f, z);
+            go.transform.localScale = Vector3.one * 0.45f;
+            var rend = go.GetComponent<Renderer>();
+            rend.material.color = OreColor(ore);
+
+            var labelGo = new GameObject("Label");
+            labelGo.transform.SetParent(go.transform, false);
+            labelGo.transform.localPosition = new Vector3(0f, 0.6f, 0f);
+            var tm = labelGo.AddComponent<TextMesh>();
+            tm.text = $"{ore}\n{amount:F1}";
+            tm.fontSize = 24;
+            tm.characterSize = 0.07f;
+            tm.anchor = TextAnchor.MiddleCenter;
+
+            _drops[id] = go;
+        }
+
+        void Despawn(string dropId)
+        {
+            if (!_drops.TryGetValue(dropId, out var go)) return;
+            if (go != null) Destroy(go);
+            _drops.Remove(dropId);
+        }
+
+        public void ClearAll()
+        {
+            foreach (var kv in _drops)
+            {
+                if (kv.Value != null) Destroy(kv.Value);
+            }
+            _drops.Clear();
+        }
+
+        static Color OreColor(string oreId) => oreId switch
+        {
+            "coal" => new Color(0.2f, 0.2f, 0.22f),
+            "copper_ore" => new Color(0.75f, 0.45f, 0.25f),
+            "iron_ore" => new Color(0.55f, 0.5f, 0.48f),
+            "diamond_ore" => new Color(0.4f, 0.85f, 0.95f),
+            _ => new Color(0.6f, 0.55f, 0.5f),
+        };
+    }
+}

--- a/cpow_client/unity/docs/CLIENT_ARCHITECTURE.md
+++ b/cpow_client/unity/docs/CLIENT_ARCHITECTURE.md
@@ -5,10 +5,11 @@
 협업 에리어 + 오픈월드(바이옴·채굴·모듈 건축)를 **메모리 상한이 있는 청크 스트림**으로 표현합니다.
 
 ```
-┌─────────────────────────┐     REST      ┌──────────────────────┐
-│  Unity CPoWWorld        │ ◄───────────► │  cpow_api            │
-│  ChunkStreamer (AOI)    │  /v1/world/*  │  cpow_engine/world   │
-│  AreaObjectRenderer     │  /v1/areas/*  │  cpow_engine/areas   │
+┌─────────────────────────┐  REST + WS   ┌──────────────────────┐
+│  Unity CPoWWorld        │ ◄──────────► │  cpow_api            │
+│  ChunkStreamer (AOI)    │ /v1/world/*  │  cpow_engine/world   │
+│  WorldStreamClient      │ /v1/world/   │  inventory · drops   │
+│  AreaObjectRenderer     │   stream     │  stream_hub (AOI)    │
 └───────────┬─────────────┘               └──────────────────────┘
             │
    ┌────────┴────────┬──────────────┐
@@ -60,8 +61,22 @@
 |--------|------|------|
 | `GetCatalogAsync` | GET `/v1/world/catalog` | 바이옴·광물·도구 |
 | `InspectCellAsync` | POST `/v1/world/cell` | 셀 + hazard audio |
-| `MineAsync` | POST `/v1/world/mine` | 채굴 |
+| `MineAsync` | POST `/v1/world/mine` | 채굴 (기본 `deposit_mode=inventory`) |
+| `GetInventoryAsync` | GET `/v1/world/inventory` | 액터 스택 조회 |
 | `ValidateBuildAsync` | POST `/v1/world/build/validate` | 모듈 건축 검증 |
+
+### World stream (`WorldStreamClient`)
+
+| 메시지 | 방향 | 용도 |
+|--------|------|------|
+| `subscribe` | C→S | area_id, actor_id, x, z, radius_m |
+| `subscribed` | S→C | 초기 inventory + AOI drops |
+| `pose` | C→S | 관찰 위치 갱신 |
+| `inventory_delta` | S→C | 채굴·줍기 스택 변경 |
+| `drop_spawn` / `drop_despawn` | S→C | `WorldDropRenderer` 큐브 |
+
+채굴 기본값은 **CreativeObject 1개씩 늘리지 않고** `ActorInventory` SoA에 적재합니다.  
+`deposit_mode`: `inventory` | `area_object` | `both` | `drop` — `submit_to_area` 로 창조 등록 여부 제어.
 
 ## 씬 흐름
 
@@ -71,18 +86,20 @@ Boot.unity
         ├─ CpowSession (area_id, user_id)
         ├─ AreasApiClient + WorldApiClient
         ├─ ChunkStreamer → ChunkPool → BiomeChunkView
+        ├─ MiningController + MiningHud (inventory SoA)
+        ├─ WorldStreamClient → WorldDropRenderer
         └─ AreaObjectRenderer (state poll)
 ```
 
 ## 다음 단계 (로드맵)
 
 - [x] 채굴 HUD — 도구·깊이·POST `/v1/world/mine` (`MiningHud`, `MiningController`)
-- [x] 채굴 결과 → `submit_creation` (`attach_mined_resource_to_area`, `creation` in mine response)
+- [x] 인벤토리 SoA + 월드 드롭 (`inventory.py`, `drops.py`, `/v1/world/inventory`)
+- [x] WebSocket AOI delta (`/v1/world/stream`, `WorldStreamClient`)
+- [x] 채굴 결과 → `submit_creation` (옵션: `deposit_mode=both`, `submit_to_area=true`)
 - [ ] Addressables / GLTFast 로 glb 스트리밍
-- [ ] WebSocket delta (`/v1/stream`) — 멀티플레이어 AOI 동기화
 - [ ] VRM / Universal RP 아바타
 - [ ] 모듈 건축 고스트 메시 프리뷰
-- [ ] 채굴 결과 → `submit_creation` 자동 연동
 
 ## Godot 클라이언트
 

--- a/cpow_engine/tests/test_world_inventory.py
+++ b/cpow_engine/tests/test_world_inventory.py
@@ -1,0 +1,95 @@
+"""월드 인벤토리·드롭·AOI."""
+
+from __future__ import annotations
+
+import unittest
+
+from cpow_engine.world.inventory import ActorInventory, InventoryLedger
+from cpow_engine.world.drops import DropRegistry
+from cpow_engine.world.aoi import in_aoi
+from cpow_engine.world.service import WorldService
+from cpow_engine.world.ores import ORE_CATALOG
+
+
+class TestInventory(unittest.TestCase):
+    def test_stack_merge(self) -> None:
+        inv = ActorInventory(actor_id="a")
+        t1 = inv.add("coal", 2.5)
+        t2 = inv.add("coal", 1.0)
+        self.assertAlmostEqual(t1, 2.5)
+        self.assertAlmostEqual(t2, 3.5)
+
+    def test_take(self) -> None:
+        inv = ActorInventory(actor_id="a")
+        inv.add("iron_ore", 5.0)
+        ok, left = inv.take("iron_ore", 2.0)
+        self.assertTrue(ok)
+        self.assertAlmostEqual(left, 3.0)
+
+
+class TestDrops(unittest.TestCase):
+    def test_in_radius(self) -> None:
+        reg = DropRegistry()
+        reg.spawn("coal", 1.0, 10.0, 10.0, "miner")
+        reg.spawn("coal", 1.0, 200.0, 200.0, "miner")
+        near = reg.in_radius(10.0, 10.0, 32.0)
+        self.assertEqual(len(near), 1)
+
+
+class TestAoi(unittest.TestCase):
+    def test_in_aoi(self) -> None:
+        self.assertTrue(in_aoi(0, 0, 50, 0, 64))
+        self.assertFalse(in_aoi(0, 0, 200, 0, 64))
+
+
+class TestMineInventory(unittest.TestCase):
+    def test_mine_deposits_inventory_not_area_object(self) -> None:
+        svc = WorldService()
+        area_id = "inv_test_area"
+        out = svc.mine(
+            area_id,
+            {
+                "actor_id": "miner1",
+                "x": 12.0,
+                "z": 8.0,
+                "depth_y": 40,
+                "tool_type": "pickaxe",
+                "tool_tier": 2,
+                "ore_id": "coal",
+                "deposit_mode": "inventory",
+            },
+        )
+        self.assertTrue(out.get("ok"), out)
+        self.assertIn("inventory", out)
+        self.assertIn("inventory_delta", out)
+        self.assertIn("world_drop", out)
+        self.assertNotIn("creation", out)
+        inv = svc.get_inventory(area_id, "miner1")
+        self.assertGreater(inv["inventory"]["stacks"].get("coal", 0), 0)
+
+    def test_pickup_drop(self) -> None:
+        svc = WorldService()
+        area_id = "pickup_area"
+        mined = svc.mine(
+            area_id,
+            {
+                "actor_id": "p1",
+                "x": 1.0,
+                "z": 1.0,
+                "depth_y": 40,
+                "tool_type": "pickaxe",
+                "tool_tier": 2,
+                "ore_id": "coal",
+                "spawn_world_drop": True,
+            },
+        )
+        drop_id = mined["world_drop"]["drop_id"]
+        runtime = svc.runtime_for(area_id)
+        self.assertEqual(runtime.drops.count(), 1)
+        picked = svc.pickup_drop(area_id, {"actor_id": "p1", "drop_id": drop_id})
+        self.assertTrue(picked.get("ok"), picked)
+        self.assertEqual(runtime.drops.count(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cpow_engine/world/aoi.py
+++ b/cpow_engine/world/aoi.py
@@ -1,0 +1,23 @@
+"""AOI — 관심 영역 거리."""
+
+from __future__ import annotations
+
+import math
+
+
+def chebyshev_distance(x1: float, z1: float, x2: float, z2: float) -> float:
+    return max(abs(x1 - x2), abs(z1 - z2))
+
+
+def in_aoi(
+    observer_x: float,
+    observer_z: float,
+    target_x: float,
+    target_z: float,
+    radius_m: float,
+) -> bool:
+    if radius_m <= 0:
+        return True
+    dx = observer_x - target_x
+    dz = observer_z - target_z
+    return math.hypot(dx, dz) <= radius_m

--- a/cpow_engine/world/drops.py
+++ b/cpow_engine/world/drops.py
@@ -1,0 +1,82 @@
+"""월드 좌표 드롭 — 채굴 위치 시각화·줍기."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+
+
+@dataclass
+class WorldDrop:
+    drop_id: str
+    ore_id: str
+    amount: float
+    x: float
+    z: float
+    actor_id: str
+    created_at: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict:
+        return {
+            "drop_id": self.drop_id,
+            "ore_id": self.ore_id,
+            "amount": round(self.amount, 3),
+            "x": round(self.x, 2),
+            "z": round(self.z, 2),
+            "actor_id": self.actor_id,
+            "created_at": self.created_at,
+        }
+
+
+@dataclass
+class DropRegistry:
+    _drops: dict[str, WorldDrop] = field(default_factory=dict)
+    max_drops: int = 512
+
+    def spawn(
+        self,
+        ore_id: str,
+        amount: float,
+        x: float,
+        z: float,
+        actor_id: str,
+    ) -> WorldDrop:
+        while len(self._drops) >= self.max_drops:
+            oldest = min(self._drops.values(), key=lambda d: d.created_at)
+            self._drops.pop(oldest.drop_id, None)
+        drop = WorldDrop(
+            drop_id=f"drop_{uuid.uuid4().hex[:10]}",
+            ore_id=ore_id,
+            amount=amount,
+            x=x,
+            z=z,
+            actor_id=actor_id,
+        )
+        self._drops[drop.drop_id] = drop
+        return drop
+
+    def get(self, drop_id: str) -> WorldDrop | None:
+        return self._drops.get(drop_id)
+
+    def remove(self, drop_id: str) -> WorldDrop | None:
+        return self._drops.pop(drop_id, None)
+
+    def count(self) -> int:
+        return len(self._drops)
+
+    def in_radius(self, x: float, z: float, radius: float) -> list[WorldDrop]:
+        r2 = radius * radius
+        out: list[WorldDrop] = []
+        for drop in self._drops.values():
+            dx = drop.x - x
+            dz = drop.z - z
+            if dx * dx + dz * dz <= r2:
+                out.append(drop)
+        return out
+
+    def to_dict(self) -> dict:
+        return {
+            "count": len(self._drops),
+            "drops": [d.to_dict() for d in self._drops.values()],
+        }

--- a/cpow_engine/world/inventory.py
+++ b/cpow_engine/world/inventory.py
@@ -1,0 +1,56 @@
+"""액터 인벤토리 — SoA 스택 (대규모 경쟁용)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ActorInventory:
+    """광물 id → 수량. 채굴 1회마다 오브젝트를 늘리지 않음."""
+
+    actor_id: str
+    stacks: dict[str, float] = field(default_factory=dict)
+
+    def add(self, ore_id: str, amount: float) -> float:
+        if amount <= 0.0:
+            return self.stacks.get(ore_id, 0.0)
+        total = round(self.stacks.get(ore_id, 0.0) + amount, 3)
+        self.stacks[ore_id] = total
+        return total
+
+    def take(self, ore_id: str, amount: float) -> tuple[bool, float]:
+        have = self.stacks.get(ore_id, 0.0)
+        if amount > have + 1e-9:
+            return False, have
+        left = round(have - amount, 3)
+        if left <= 0.0:
+            self.stacks.pop(ore_id, None)
+        else:
+            self.stacks[ore_id] = left
+        return True, left
+
+    def get(self, ore_id: str) -> float:
+        return self.stacks.get(ore_id, 0.0)
+
+    def to_dict(self) -> dict:
+        return {
+            "actor_id": self.actor_id,
+            "stacks": dict(sorted(self.stacks.items())),
+            "slot_count": len(self.stacks),
+        }
+
+
+@dataclass
+class InventoryLedger:
+    """에리어 단위 인벤토리 저장소."""
+
+    _actors: dict[str, ActorInventory] = field(default_factory=dict)
+
+    def for_actor(self, actor_id: str) -> ActorInventory:
+        if actor_id not in self._actors:
+            self._actors[actor_id] = ActorInventory(actor_id=actor_id)
+        return self._actors[actor_id]
+
+    def to_public_dict(self, actor_id: str) -> dict:
+        return {"ok": True, "inventory": self.for_actor(actor_id).to_dict()}

--- a/cpow_engine/world/service.py
+++ b/cpow_engine/world/service.py
@@ -12,6 +12,7 @@ from cpow_engine.world.hazards import advance_hazard, hazard_snapshot
 from cpow_engine.world.mining import attempt_mine, parse_tool_from_payload
 from cpow_engine.world.ores import ORE_CATALOG, ore_catalog_public
 from cpow_engine.world.state import AreaWorldRuntime
+from cpow_engine.world.stream_hub import get_stream_hub
 from cpow_engine.world.tools import tool_catalog_public
 
 
@@ -59,6 +60,109 @@ class WorldService:
         snap["area_id"] = area_id
         return snap
 
+    def _emit_stream(self, area_id: str, event: dict) -> None:
+        get_stream_hub().publish_sync(area_id, event)
+
+    def _deposit_mine_yield(
+        self,
+        runtime: AreaWorldRuntime,
+        area_id: str,
+        actor_id: str,
+        x: float,
+        z: float,
+        payload: dict,
+        out: dict,
+    ) -> None:
+        ore_id = str(out.get("ore_id", ""))
+        amount = float(out.get("amount", 0.0))
+        if not ore_id or amount <= 0.0:
+            return
+
+        deposit_mode = str(payload.get("deposit_mode", "inventory")).lower()
+        spawn_drop = bool(payload.get("spawn_world_drop", True))
+
+        if deposit_mode in ("inventory", "both"):
+            inv = runtime.inventory.for_actor(actor_id)
+            total = inv.add(ore_id, amount)
+            out["inventory"] = inv.to_dict()
+            delta = {
+                "type": "inventory_delta",
+                "area_id": area_id,
+                "actor_id": actor_id,
+                "ore_id": ore_id,
+                "amount": amount,
+                "total": total,
+                "x": x,
+                "z": z,
+            }
+            out["inventory_delta"] = delta
+            self._emit_stream(area_id, delta)
+
+        if spawn_drop and deposit_mode in ("inventory", "both", "drop"):
+            drop = runtime.drops.spawn(ore_id, amount, x, z, actor_id)
+            out["world_drop"] = drop.to_dict()
+            self._emit_stream(area_id, {
+                "type": "drop_spawn",
+                "area_id": area_id,
+                **drop.to_dict(),
+            })
+
+    def get_inventory(self, area_id: str, actor_id: str) -> dict:
+        runtime = self.runtime_for(area_id)
+        return runtime.inventory.to_public_dict(actor_id)
+
+    def drops_in_aoi(
+        self,
+        area_id: str,
+        x: float,
+        z: float,
+        radius_m: float = 128.0,
+    ) -> dict:
+        runtime = self.runtime_for(area_id)
+        drops = [d.to_dict() for d in runtime.drops.in_radius(x, z, radius_m)]
+        return {"ok": True, "area_id": area_id, "drops": drops, "count": len(drops)}
+
+    def pickup_drop(
+        self,
+        area_id: str,
+        payload: dict,
+    ) -> dict:
+        runtime = self.runtime_for(area_id)
+        actor_id = str(payload.get("actor_id", "anonymous"))
+        drop_id = str(payload.get("drop_id", ""))
+        drop = runtime.drops.remove(drop_id)
+        if drop is None:
+            return {"ok": False, "reason": "drop_not_found", "area_id": area_id}
+        inv = runtime.inventory.for_actor(actor_id)
+        total = inv.add(drop.ore_id, drop.amount)
+        out = {
+            "ok": True,
+            "reason": "picked_up",
+            "area_id": area_id,
+            "drop_id": drop_id,
+            "ore_id": drop.ore_id,
+            "amount": drop.amount,
+            "inventory": inv.to_dict(),
+        }
+        self._emit_stream(area_id, {
+            "type": "drop_despawn",
+            "area_id": area_id,
+            "drop_id": drop_id,
+            "x": drop.x,
+            "z": drop.z,
+        })
+        self._emit_stream(area_id, {
+            "type": "inventory_delta",
+            "area_id": area_id,
+            "actor_id": actor_id,
+            "ore_id": drop.ore_id,
+            "amount": drop.amount,
+            "total": total,
+            "x": drop.x,
+            "z": drop.z,
+        })
+        return out
+
     def mine(
         self,
         area_id: str,
@@ -105,6 +209,8 @@ class WorldService:
             "audio_stage": phase.audio_stage,
             "phase_id": phase.phase_id,
         }
+        if out.get("ok"):
+            self._deposit_mine_yield(runtime, area_id, actor_id, x, z, payload, out)
         return out
 
     def validate_build(self, payload: dict) -> dict:
@@ -142,13 +248,19 @@ class WorldService:
         profile = runtime.miner_profile(actor_id)
         amount = float(payload.get("amount", 1.0))
         apply_mining_xp(profile, ore.ore_id, amount)
-        return {
+        out = {
             "ok": True,
             "reason": "boss_loot",
             "area_id": area_id,
+            "ore_id": ore.ore_id,
+            "amount": amount,
             "resource": build_resource_object(actor_id, ore.ore_id, amount).to_dict(),
             "mining": profile.to_dict(),
         }
+        x = float(payload.get("x", 0.0))
+        z = float(payload.get("z", 0.0))
+        self._deposit_mine_yield(runtime, area_id, actor_id, x, z, payload, out)
+        return out
 
 
 _DEFAULT = WorldService()

--- a/cpow_engine/world/state.py
+++ b/cpow_engine/world/state.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from cpow_engine.world.drops import DropRegistry
 from cpow_engine.world.hazards import HazardState
+from cpow_engine.world.inventory import InventoryLedger
 from cpow_engine.world.mining import MiningProfile
 
 
@@ -14,6 +16,8 @@ class AreaWorldRuntime:
     world_seed: str
     cell_hazards: dict[tuple[int, int], HazardState] = field(default_factory=dict)
     miners: dict[str, MiningProfile] = field(default_factory=dict)
+    inventory: InventoryLedger = field(default_factory=InventoryLedger)
+    drops: DropRegistry = field(default_factory=DropRegistry)
     world_tick: int = 0
 
     def hazard_state_for(self, cell_x: int, cell_z: int) -> HazardState:
@@ -34,4 +38,5 @@ class AreaWorldRuntime:
             "world_tick": self.world_tick,
             "miner_count": len(self.miners),
             "hazard_cells": len(self.cell_hazards),
+            "drop_count": self.drops.count(),
         }

--- a/cpow_engine/world/stream_hub.py
+++ b/cpow_engine/world/stream_hub.py
@@ -1,0 +1,94 @@
+"""월드 스트림 이벤트 — WebSocket AOI delta."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from dataclasses import dataclass, field
+from queue import Empty, Full, Queue
+from typing import Any
+
+
+@dataclass
+class StreamSubscription:
+    connection_id: str
+    area_id: str
+    actor_id: str
+    x: float
+    z: float
+    radius_m: float = 128.0
+    queue: Queue = field(default_factory=Queue)
+
+    def matches_aoi(self, event: dict[str, Any]) -> bool:
+        from cpow_engine.world.aoi import in_aoi
+
+        ex = float(event.get("x", self.x))
+        ez = float(event.get("z", self.z))
+        if event.get("type") == "inventory_delta":
+            return str(event.get("actor_id", "")) == self.actor_id
+        return in_aoi(self.x, self.z, ex, ez, self.radius_m)
+
+
+class WorldStreamHub:
+    """에리어별 구독 — delta만 푸시 (thread-safe queue)."""
+
+    def __init__(self) -> None:
+        self._subs: dict[str, StreamSubscription] = {}
+
+    async def subscribe(self, sub: StreamSubscription) -> None:
+        self._subs[sub.connection_id] = sub
+
+    async def unsubscribe(self, connection_id: str) -> None:
+        self._subs.pop(connection_id, None)
+
+    async def update_pose(
+        self,
+        connection_id: str,
+        x: float,
+        z: float,
+        radius_m: float | None = None,
+    ) -> None:
+        sub = self._subs.get(connection_id)
+        if sub is None:
+            return
+        sub.x = x
+        sub.z = z
+        if radius_m is not None:
+            sub.radius_m = radius_m
+
+    def publish_sync(self, area_id: str, event: dict[str, Any]) -> int:
+        event = {**event, "ts": time.time()}
+        sent = 0
+        for sub in self._subs.values():
+            if sub.area_id != area_id or not sub.matches_aoi(event):
+                continue
+            try:
+                sub.queue.put_nowait(event)
+                sent += 1
+            except Full:
+                pass
+        return sent
+
+    async def drain(self, connection_id: str, timeout: float = 25.0) -> dict[str, Any] | None:
+        sub = self._subs.get(connection_id)
+        if sub is None:
+            return None
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                return sub.queue.get_nowait()
+            except Empty:
+                await asyncio.sleep(0.05)
+        return {"type": "ping", "ts": time.time()}
+
+    @staticmethod
+    def dumps(event: dict[str, Any]) -> str:
+        return json.dumps(event, ensure_ascii=False)
+
+
+_HUB = WorldStreamHub()
+
+
+def get_stream_hub() -> WorldStreamHub:
+    return _HUB

--- a/tests/test_cpow_api_flow.py
+++ b/tests/test_cpow_api_flow.py
@@ -176,12 +176,16 @@ class TestCpowWorldApiFlow(unittest.TestCase):
         self.assertEqual(mined.status_code, 200, mined.json())
         mined_body = mined.json()
         self.assertTrue(mined_body.get("ok"), mined_body)
-        self.assertIn("creation", mined_body)
-        self.assertTrue(mined_body["creation"].get("ok"), mined_body.get("creation"))
-        self.assertIn("object_id", mined_body)
+        self.assertIn("inventory", mined_body)
+        self.assertIn("inventory_delta", mined_body)
+        self.assertIn("world_drop", mined_body)
+        self.assertNotIn("creation", mined_body)
 
-        state = self.client.get(f"/v1/areas/state?area_id={area_id}")
-        self.assertGreaterEqual(len(state.json()["state"]["objects"]), 1)
+        inv = self.client.get(
+            f"/v1/world/inventory?area_id={area_id}&actor_id=miner_u",
+        )
+        self.assertTrue(inv.json().get("ok"))
+        self.assertGreater(inv.json()["inventory"]["stacks"].get("coal", 0), 0)
 
         adventure = self.client.post(
             "/v1/areas/adventure",
@@ -200,7 +204,34 @@ class TestCpowWorldApiFlow(unittest.TestCase):
         self.assertEqual(adventure.status_code, 200, adventure.json())
         self.assertTrue(adventure.json().get("ok"), adventure.json())
         self.assertEqual(adventure.json().get("action"), "mine")
-        self.assertIn("creation", adventure.json())
+        self.assertIn("inventory", adventure.json())
+
+    def test_world_mine_area_object_mode(self) -> None:
+        found = self.client.post(
+            "/v1/areas/found",
+            json={"founder_id": "obj_u", "label": "오브젝트 채굴"},
+        )
+        area_id = found.json()["area"]["area_id"]
+        mined = self.client.post(
+            "/v1/world/mine",
+            json={
+                "area_id": area_id,
+                "actor_id": "obj_u",
+                "x": 10.0,
+                "z": 10.0,
+                "depth_y": 40,
+                "tool_type": "pickaxe",
+                "tool_tier": 2,
+                "ore_id": "coal",
+                "deposit_mode": "both",
+                "submit_to_area": True,
+            },
+        )
+        body = mined.json()
+        self.assertTrue(body.get("ok"), body)
+        self.assertIn("inventory", body)
+        self.assertIn("creation", body)
+        self.assertTrue(body["creation"].get("ok"), body.get("creation"))
 
     def test_world_mine_skip_area_submit(self) -> None:
         found = self.client.post(
@@ -225,6 +256,7 @@ class TestCpowWorldApiFlow(unittest.TestCase):
         body = mined.json()
         self.assertTrue(body.get("ok"), body)
         self.assertNotIn("creation", body)
+        self.assertIn("inventory", body)
 
     def test_world_build_validate_and_boss_loot(self) -> None:
         build = self.client.post(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

대규모 경쟁을 위한 월드 자원 기반을 추가합니다. 채굴 시 CreativeObject를 매번 늘리지 않고 **액터 인벤토리 SoA**에 적재하며, 선택적으로 **월드 좌표 드롭**과 **AOI WebSocket delta**로 동기화합니다.

## Changes

### Engine (`cpow_engine/world/`)
- `inventory.py` — `ActorInventory`, `InventoryLedger` (ore_id → amount stacks)
- `drops.py` — `WorldDrop`, `DropRegistry` (x,z spawn, radius query, LRU cap)
- `aoi.py` — `in_aoi()` distance check
- `stream_hub.py` — thread-safe `WorldStreamHub` with AOI-filtered events
- `service.py` — `_deposit_mine_yield()`, `get_inventory()`, `drops_in_aoi()`, `pickup_drop()`
- `state.py` — `AreaWorldRuntime` holds inventory + drops

### API (`cpow_api/`)
- `GET /v1/world/inventory`
- `POST /v1/world/drops` — AOI drop list
- `POST /v1/world/pickup`
- `WebSocket /v1/world/stream` — subscribe/pose + `inventory_delta`, `drop_spawn`, `drop_despawn`
- `WorldMineRequest`: `deposit_mode` (`inventory` | `area_object` | `both` | `drop`), `spawn_world_drop`, `submit_to_area: false` default

### Unity client
- `WorldStreamClient` — WebSocket subscribe + pose updates
- `WorldDropRenderer` — spawn/despawn drop cubes from stream
- `MiningHud` — inventory stack display
- `GameBootstrap` — stream wiring on boot

### Tests
- `cpow_engine/tests/test_world_inventory.py`
- Updated `tests/test_cpow_api_flow.py` for inventory default path

## Default mining behavior

| Field | Default |
|-------|---------|
| `deposit_mode` | `inventory` |
| `spawn_world_drop` | `true` |
| `submit_to_area` | `false` |

Use `deposit_mode=both` + `submit_to_area=true` to keep the previous mine→`submit_creation` flow.

## Verification

```bash
python3 -m unittest discover -s cpow_engine/tests -v
python3 -m unittest tests.test_cpow_api_flow -v
```

All 181 engine + 14 API flow tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f2b450d-0aad-4b1b-8498-a8fcb841156a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f2b450d-0aad-4b1b-8498-a8fcb841156a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

